### PR TITLE
Parameters per query tab fix

### DIFF
--- a/Src/SwqlStudio/CachedParameters.cs
+++ b/Src/SwqlStudio/CachedParameters.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SolarWinds.InformationService.Contract2;
+
+namespace SwqlStudio
+{
+    internal class CachedParameters
+    {
+        private readonly Dictionary<string, string> lastKnownValues = new Dictionary<string, string>();
+
+        internal void UpdateFromCachedValues(PropertyBag toUpdate, PropertyBag current)
+        {
+            UpdateFromLastKnown(toUpdate);
+            UpdateWithCurrentValues(toUpdate, current);
+            QuessRenamedParameter(toUpdate, current);
+        }
+
+        private void UpdateFromLastKnown(PropertyBag propertyBag)
+        {
+            foreach (string preservedKey in lastKnownValues.Keys.Where(propertyBag.ContainsKey))
+            {
+                propertyBag[preservedKey] = lastKnownValues[preservedKey];
+            }
+        }
+
+        private void UpdateWithCurrentValues(PropertyBag toUpdate, PropertyBag current)
+        {
+            foreach (var variable in current)
+            {
+                if (toUpdate.ContainsKey(variable.Key))
+                {
+                    toUpdate[variable.Key] = variable.Value;
+                }
+                else
+                {
+                    string lastKnownValue = variable.Value?.ToString();
+                        
+                    if (!String.IsNullOrEmpty(lastKnownValue))
+                        lastKnownValues[variable.Key] = lastKnownValue;
+                }
+            }
+        }
+
+        private void QuessRenamedParameter(PropertyBag propertyBag, PropertyBag currentVariables)
+        {
+            // we are able to identify only one renamed parameter using this simple concept
+            var added = propertyBag.Keys.Except(currentVariables.Keys).ToList();
+            var removed = currentVariables.Keys.Except(propertyBag.Keys).ToList();
+            if (added.Count == 1 && removed.Count == 1)
+            {
+                propertyBag[added.First()] = currentVariables[removed.First()];
+            }
+        }
+    }
+}

--- a/Src/SwqlStudio/CachedParameters.cs
+++ b/Src/SwqlStudio/CachedParameters.cs
@@ -1,32 +1,61 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using SolarWinds.InformationService.Contract2;
 
 namespace SwqlStudio
 {
     internal class CachedParameters
     {
-        private readonly Dictionary<string, string> lastKnownValues = new Dictionary<string, string>();
+        private static readonly Regex queryParamRegEx = new Regex(@"\@([\w.$]+|""[^""]+""|'[^']+')", RegexOptions.Compiled);
+        private static readonly Dictionary<string, string> lastKnownValues = new Dictionary<string, string>();
+        private PropertyBag current = new PropertyBag();
 
-        internal void UpdateFromCachedValues(PropertyBag toUpdate, PropertyBag current)
+        internal void Put(PropertyBag toPreserve)
         {
-            UpdateFromLastKnown(toUpdate);
-            UpdateWithCurrentValues(toUpdate, current);
-            QuessRenamedParameter(toUpdate, current);
+            this.current = toPreserve;
         }
 
-        private void UpdateFromLastKnown(PropertyBag propertyBag)
+        internal PropertyBag Get(string query)
         {
-            foreach (string preservedKey in lastKnownValues.Keys.Where(propertyBag.ContainsKey))
+            var parsed = ParseText(query);
+            UpdateFromCachedValues(parsed);
+            this.Put(parsed);
+            return parsed;
+        }
+
+        private static PropertyBag ParseText(string query)
+        {
+            var parsed = new PropertyBag();
+
+            foreach (Match item in queryParamRegEx.Matches(query))
             {
-                propertyBag[preservedKey] = lastKnownValues[preservedKey];
+                string paramName = item.Value.Substring(1);
+                parsed[paramName] = string.Empty;
+            }
+
+            return parsed;
+        }
+
+        private void UpdateFromCachedValues(PropertyBag toUpdate)
+        {
+            UpdateFromLastKnown(toUpdate);
+            UpdateWithCurrentValues(toUpdate);
+            QuessRenamedParameter(toUpdate);
+        }
+
+        private void UpdateFromLastKnown(PropertyBag toUpdate)
+        {
+            foreach (string preservedKey in lastKnownValues.Keys.Where(toUpdate.ContainsKey))
+            {
+                toUpdate[preservedKey] = lastKnownValues[preservedKey];
             }
         }
 
-        private void UpdateWithCurrentValues(PropertyBag toUpdate, PropertyBag current)
+        private void UpdateWithCurrentValues(PropertyBag toUpdate)
         {
-            foreach (var variable in current)
+            foreach (var variable in this.current)
             {
                 if (toUpdate.ContainsKey(variable.Key))
                 {
@@ -42,14 +71,14 @@ namespace SwqlStudio
             }
         }
 
-        private void QuessRenamedParameter(PropertyBag propertyBag, PropertyBag currentVariables)
+        private void QuessRenamedParameter(PropertyBag toUpdate)
         {
             // we are able to identify only one renamed parameter using this simple concept
-            var added = propertyBag.Keys.Except(currentVariables.Keys).ToList();
-            var removed = currentVariables.Keys.Except(propertyBag.Keys).ToList();
+            var added = toUpdate.Keys.Except(this.current.Keys).ToList();
+            var removed = this.current.Keys.Except(toUpdate.Keys).ToList();
             if (added.Count == 1 && removed.Count == 1)
             {
-                propertyBag[added.First()] = currentVariables[removed.First()];
+                toUpdate[added.First()] = this.current[removed.First()];
             }
         }
     }

--- a/Src/SwqlStudio/QueriesDockPanel.cs
+++ b/Src/SwqlStudio/QueriesDockPanel.cs
@@ -135,11 +135,15 @@ namespace SwqlStudio
 
         private void FilesDock_ActiveContentChanged(object sender, EventArgs e)
         {
-            var content = this.ActiveContent as DockContent;
-            if (content != null &&  (content != this.objectExplorerContent || content != this.queryParametersContent))
+            var newContent = this.ActiveContent as DockContent;
+            if (newContent != null &&  
+                newContent != this.objectExplorerContent &&
+                newContent != this.queryParametersContent &&
+                newContent != this.lastActiveContent)
             {
-                this.lastActiveContent = content;
-                this.ActiveQueryTab?.DetectQueryParameters();
+                this.ActiveQueryTab?.PutParameters();
+                this.lastActiveContent = newContent;
+                this.ActiveQueryTab?.ParseParameters();
             }
         }
 

--- a/Src/SwqlStudio/QueryParameters.cs
+++ b/Src/SwqlStudio/QueryParameters.cs
@@ -8,7 +8,7 @@ namespace SwqlStudio
 {
     public partial class QueryParameters : DockContent
     {
-        private readonly Dictionary<string, string> lastKnownValues = new Dictionary<string, string>();
+        private CachedParameters preserved = new CachedParameters();
 
         public bool AllowSetParameters { get; set; }
 
@@ -35,25 +35,10 @@ namespace SwqlStudio
                 if (!this.AllowSetParameters)
                     return;
 
-                UpdateFromLastKnown(value);
-                var currentVariables = GetBoundQueryVariables();
-                UpdateWithCurrentValues(value, currentVariables);
-                var pairs = value.Select(pair => new QueryVariable(pair.Key, pair.Value?.ToString()));
-                QuessRenamedParameter(value);
-                var ordered = pairs.OrderBy(p => p.Key).ToList();
+                preserved.UpdateFromCachedValues(value, this.Parameters);
+                var ordered = value.Select(pair => new QueryVariable(pair.Key, pair.Value?.ToString()))
+                                   .OrderBy(p => p.Key).ToList();
                 parametersGrid.DataSource = new BindingList<QueryVariable>(ordered) { AllowNew = true };
-            }
-        }
-
-        private void QuessRenamedParameter(PropertyBag propertyBag)
-        {
-            // we are able to identify only one renamed parameter using this simple concept
-            var currentVariables = Parameters;
-            var added = propertyBag.Keys.Except(currentVariables.Keys).ToList();
-            var removed = currentVariables.Keys.Except(propertyBag.Keys).ToList();
-            if (added.Count == 1 && removed.Count == 1)
-            {
-                propertyBag[added.First()] = currentVariables[removed.First()];
             }
         }
 
@@ -61,29 +46,6 @@ namespace SwqlStudio
         {
             return ((BindingList<QueryVariable>)parametersGrid.DataSource)
                 .Where(v => v.Key != null);
-        }
-
-        private void UpdateWithCurrentValues(PropertyBag propertyBag, IEnumerable<QueryVariable> currentVariables)
-        {
-            foreach (QueryVariable variable in currentVariables)
-            {
-                if (propertyBag.ContainsKey(variable.Key))
-                {
-                    propertyBag[variable.Key] = variable.Value;
-                }
-                else if (!string.IsNullOrEmpty(variable.Value))
-                {
-                    lastKnownValues[variable.Key] = variable.Value;
-                }
-            }
-        }
-
-        private void UpdateFromLastKnown(PropertyBag propertyBag)
-        {
-            foreach (string preservedKey in lastKnownValues.Keys.Where(propertyBag.ContainsKey))
-            {
-                propertyBag[preservedKey] = lastKnownValues[preservedKey];
-            }
         }
     }
 }

--- a/Src/SwqlStudio/QueryParameters.cs
+++ b/Src/SwqlStudio/QueryParameters.cs
@@ -8,8 +8,6 @@ namespace SwqlStudio
 {
     public partial class QueryParameters : DockContent
     {
-        private CachedParameters preserved = new CachedParameters();
-
         public bool AllowSetParameters { get; set; }
 
         public QueryParameters()
@@ -35,9 +33,9 @@ namespace SwqlStudio
                 if (!this.AllowSetParameters)
                     return;
 
-                preserved.UpdateFromCachedValues(value, this.Parameters);
                 var ordered = value.Select(pair => new QueryVariable(pair.Key, pair.Value?.ToString()))
-                                   .OrderBy(p => p.Key).ToList();
+                                   .OrderBy(p => p.Key)
+                                   .ToList();
                 parametersGrid.DataSource = new BindingList<QueryVariable>(ordered) { AllowNew = true };
             }
         }

--- a/Src/SwqlStudio/SwqlStudio.csproj
+++ b/Src/SwqlStudio/SwqlStudio.csproj
@@ -123,6 +123,7 @@
     <Compile Include="ActivityMonitorTab.Designer.cs">
       <DependentUpon>ActivityMonitorTab.cs</DependentUpon>
     </Compile>
+    <Compile Include="CachedParameters.cs" />
     <Compile Include="ConnectionHistory.cs" />
     <Compile Include="ConnectionInfo.cs" />
     <Compile Include="ConnectionsManager.cs" />


### PR DESCRIPTION
Query parameters are now preserved per tab and last known values work across all tabs.