### PR TITLE
Fixed remove last connection

### DIFF
--- a/Src/SwqlStudio/ActivityMonitorTab.cs
+++ b/Src/SwqlStudio/ActivityMonitorTab.cs
@@ -4,17 +4,23 @@ using SwqlStudio.Subscriptions;
 
 namespace SwqlStudio
 {
-    public partial class ActivityMonitorTab : UserControl, IConnectionTab
+    public partial class ActivityMonitorTab : TabTemplate, IConnectionTab
     {
         private string subscriptionId;
-
-        public ConnectionInfo ConnectionInfo { get; set; }
+        private bool conneciotnSet = false;
 
         public SubscriptionManager SubscriptionManager { get; set; }
 
-        public bool AllowsChangeConnection
+        public override bool AllowsChangeConnection => !this.conneciotnSet;
+
+        public override ConnectionInfo ConnectionInfo
         {
-            get { return false; }
+            get { return base.ConnectionInfo; }
+            set
+            {
+                base.ConnectionInfo = value;
+                this.conneciotnSet = true;
+            }
         }
 
         public ActivityMonitorTab()

--- a/Src/SwqlStudio/ConnectionInfo.cs
+++ b/Src/SwqlStudio/ConnectionInfo.cs
@@ -406,5 +406,10 @@ namespace SwqlStudio
                 return hashCode;
             }
         }
+
+        public override string ToString()
+        {
+            return this.Title;
+        }
     }
 }

--- a/Src/SwqlStudio/ConnectionsEventArgs.cs
+++ b/Src/SwqlStudio/ConnectionsEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SwqlStudio
+{
+    internal class ConnectionsEventArgs : EventArgs
+    {
+        internal ConnectionInfo Connection { get; private set; }
+
+        public ConnectionsEventArgs(ConnectionInfo connection)
+        {
+            this.Connection = connection;
+        }
+    }
+}

--- a/Src/SwqlStudio/ConnectionsManager.cs
+++ b/Src/SwqlStudio/ConnectionsManager.cs
@@ -6,13 +6,11 @@ namespace SwqlStudio
     {
         private readonly IApplicationService applicationService;
         private readonly ServerList serverList;
-        private readonly QueriesDockPanel dockPanel;
 
-        public ConnectionsManager(IApplicationService applicationService, ServerList serverList, QueriesDockPanel dockPanel)
+        public ConnectionsManager(IApplicationService applicationService, ServerList serverList)
         {
             this.applicationService = applicationService;
             this.serverList = serverList;
-            this.dockPanel = dockPanel;
         }
 
         public void CreateConnection()
@@ -48,14 +46,8 @@ namespace SwqlStudio
                 return found;
 
             info.Connect();
-            var provider = serverList.Add(info);
-
-            info.ConnectionClosed += (sender, args) =>
-            {
-                serverList.Remove(info);
-            };
-
-            this.dockPanel.AddServer(provider, info);
+            info.ConnectionClosed += (sender, args) => serverList.Remove(info);
+            serverList.Add(info);
             return info;
         }
 

--- a/Src/SwqlStudio/ConnectionsManager.cs
+++ b/Src/SwqlStudio/ConnectionsManager.cs
@@ -52,7 +52,6 @@ namespace SwqlStudio
 
             info.ConnectionClosed += (sender, args) =>
             {
-                this.dockPanel.CloseAllFixedConnectionTabs(info);
                 serverList.Remove(info);
             };
 

--- a/Src/SwqlStudio/CrudTab.cs
+++ b/Src/SwqlStudio/CrudTab.cs
@@ -6,7 +6,7 @@ using SwqlStudio.Metadata;
 
 namespace SwqlStudio
 {
-    public partial class CrudTab : UserControl, IConnectionTab
+    public partial class CrudTab : TabTemplate, IConnectionTab
     {
         private const int ControlsMargin = 3;
         private readonly CrudOperation _operation;
@@ -30,11 +30,6 @@ namespace SwqlStudio
                 CreateSubComponents();
             }
         }
-
-        /// <inheritdoc />
-        public ConnectionInfo ConnectionInfo { get; set; }
-
-        public bool AllowsChangeConnection => true;
 
         public event EventHandler CloseItself;
 
@@ -90,6 +85,9 @@ namespace SwqlStudio
 
         private void OnCommit(object sender, EventArgs e)
         {
+            if (ConnectionInfo == null)
+                return;
+
             var propertyBag = CreatePropertyBag();
 
             try

--- a/Src/SwqlStudio/InvokeVerbTab.cs
+++ b/Src/SwqlStudio/InvokeVerbTab.cs
@@ -10,15 +10,13 @@ using UserControl = System.Windows.Forms.UserControl;
 
 namespace SwqlStudio
 {
-    public partial class InvokeVerbTab : UserControl, IConnectionTab
+    public partial class InvokeVerbTab : TabTemplate, IConnectionTab
     {
         public InvokeVerbTab()
         {
             InitializeComponent();
         }
 
-        public ConnectionInfo ConnectionInfo { get; set; }
-        public bool AllowsChangeConnection => true;
         private int locationX = 0;
         private int locationY = 0;
 
@@ -127,6 +125,9 @@ namespace SwqlStudio
 
         private void Invoke_Click(object sender, HtmlElementEventArgs e)
         {
+            if (ConnectionInfo == null)
+                return;
+
             bool argumentParsingFailed = false;
 
             XmlElement[] parameters = verb.Arguments.Select(argument =>

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -34,6 +34,7 @@ namespace SwqlStudio
         public ConnectionInfo SelectedConnection
         {
             get { return this.connectionsCombobox.SelectedItem as ConnectionInfo; }
+            set { this.connectionsCombobox.SelectedItem = value; }
         }
 
         public MainForm()
@@ -75,7 +76,7 @@ namespace SwqlStudio
             IConnectionTab activeConnectionTab = this.filesDock.ActiveConnectionTab;
             if (activeConnectionTab != null)
             {
-                this.connectionsCombobox.SelectedItem = activeConnectionTab.ConnectionInfo;
+                this.SelectedConnection = activeConnectionTab.ConnectionInfo;
             }
         }
 
@@ -91,7 +92,7 @@ namespace SwqlStudio
             this.connectionsDataSource.Add(addedConnection);
             this.serverList.TryGetProvider(addedConnection, out IMetadataProvider provider);
             this.filesDock.AddServer(provider, addedConnection);
-            this.connectionsCombobox.SelectedItem = addedConnection;
+            this.SelectedConnection = addedConnection;
         }
 
         private void ServerListOnConnectionRemoved(object sender, ConnectionsEventArgs e)
@@ -100,7 +101,7 @@ namespace SwqlStudio
             this.connectionsDataSource.Remove(e.Connection);
 
             if(connectionsDataSource.Any())
-                this.connectionsCombobox.SelectedItem = connectionsDataSource.First();
+                this.SelectedConnection = connectionsDataSource.First();
         }
 
         private void startTimer_Tick(object sender, EventArgs e)
@@ -434,17 +435,14 @@ namespace SwqlStudio
 
         private void disconnectToolButton_Click(object sender, EventArgs e)
         {
-            var connection = this.connectionsCombobox.SelectedItem as ConnectionInfo;
-            connection?.Close();
+            this.SelectedConnection?.Close();
         }
 
         private void refreshToolButton_Click(object sender, EventArgs e)
         {
-            var connection = this.connectionsCombobox.SelectedItem as ConnectionInfo;
+            var connection = this.SelectedConnection;
             if (connection != null)
-            {
                 this.filesDock.RefreshServer(connection);
-            }
         }
 
         private void editToolStripMenuItem_DropDownOpening(object sender, EventArgs e)

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -57,6 +57,7 @@ namespace SwqlStudio
             this.filesDock.SetObjectExplorerImageList(this.ObjectExplorerImageList);
             this.serverList = new ServerList();
             this.serverList.ConnectionsChanged += ServerListOnConnectionsChanged;
+            this.serverList.ConnectionRemoved += ServerListOnConnectionRemoved;
             this.connectionsManager = new ConnectionsManager(this, this.serverList, this.filesDock);
             var tabsFactory = new TabsFactory(this.filesDock, this, this.serverList, this.connectionsManager);
             this.filesDock.SetAplicationService(tabsFactory);
@@ -91,6 +92,11 @@ namespace SwqlStudio
                 lastSelected = serverListConnections.First();
             
             this.connectionsCombobox.SelectedItem = lastSelected;
+        }
+
+        private void ServerListOnConnectionRemoved(object sender, ConnectionsEventArgs e)
+        {
+            this.filesDock.CloseServer(e.Connection);
         }
 
         private void startTimer_Tick(object sender, EventArgs e)
@@ -425,10 +431,7 @@ namespace SwqlStudio
         private void disconnectToolButton_Click(object sender, EventArgs e)
         {
             var connection = this.connectionsCombobox.SelectedItem as ConnectionInfo;
-            if (connection != null)
-            {
-                this.filesDock.CloseServer(connection);
-            }
+            connection?.Close();
         }
 
         private void refreshToolButton_Click(object sender, EventArgs e)

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -93,6 +93,9 @@ namespace SwqlStudio
             this.serverList.TryGetProvider(addedConnection, out IMetadataProvider provider);
             this.filesDock.AddServer(provider, addedConnection);
             this.SelectedConnection = addedConnection;
+
+            if (this.connectionsDataSource.Count == 1)
+                this.filesDock.ReplaceConnection(null, addedConnection);
         }
 
         private void ServerListOnConnectionRemoved(object sender, ConnectionsEventArgs e)
@@ -468,7 +471,7 @@ namespace SwqlStudio
 
         private void CopyQueryAs(Func<string, ConnectionInfo, string> formatter)
         {
-            var connection = filesDock.ActiveConnectionTab.ConnectionInfo;
+            var connection = filesDock.ActiveConnectionTab?.ConnectionInfo;
             if (connection == null)
                 return;
 

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -97,11 +97,12 @@ namespace SwqlStudio
 
         private void ServerListOnConnectionRemoved(object sender, ConnectionsEventArgs e)
         {
-            this.filesDock.CloseServer(e.Connection);
             this.connectionsDataSource.Remove(e.Connection);
 
             if(connectionsDataSource.Any())
                 this.SelectedConnection = connectionsDataSource.First();
+
+            this.filesDock.CloseServer(e.Connection, this.SelectedConnection);
         }
 
         private void startTimer_Tick(object sender, EventArgs e)
@@ -257,7 +258,7 @@ namespace SwqlStudio
         private void TextEditor_FormClosing(object sender, FormClosingEventArgs e)
         {
             // Ask user to save changes
-            foreach (var editor in this.filesDock.AllEditors)
+            foreach (var editor in this.filesDock.QueryTabs)
             {
                 if (editor.Modified && Settings.Default.PromptToSaveOnClose)
                 {
@@ -468,6 +469,9 @@ namespace SwqlStudio
         private void CopyQueryAs(Func<string, ConnectionInfo, string> formatter)
         {
             var connection = filesDock.ActiveConnectionTab.ConnectionInfo;
+            if (connection == null)
+                return;
+
             var query = filesDock.ActiveQueryTab.QueryText;
             string command = formatter(query, connection);
             Clipboard.SetText(command);

--- a/Src/SwqlStudio/QueriesDockPanel.cs
+++ b/Src/SwqlStudio/QueriesDockPanel.cs
@@ -44,16 +44,11 @@ namespace SwqlStudio
         }
 
         /// <summary>Returns a list of all editor controls</summary>
-        internal IEnumerable<QueryTab> AllEditors
+        internal IEnumerable<QueryTab> QueryTabs
         {
-            get
-            {
-                return from t in this.Contents.OfType<DockContent>()
-                    from c in t.Controls.OfType<QueryTab>()
-                    select c;
-            }
+            get { return GetAllControlsOnTabs<QueryTab>(); }
         }
-
+        
         public QueriesDockPanel()
         {
             InitializeComponent();
@@ -257,15 +252,27 @@ namespace SwqlStudio
             }
         }
 
-        internal void CloseServer(ConnectionInfo connection)
-        {
-            this.objectExplorer.CloseServer(connection);
-            this.CloseAllFixedConnectionTabs(connection);
-        }
-
         internal void RefreshServer(ConnectionInfo connection)
         {
             this.objectExplorer.RefreshServer(connection);
+        }
+
+        internal void CloseServer(ConnectionInfo current, ConnectionInfo replacement)
+        {
+            this.objectExplorer.CloseServer(current);
+            this.CloseAllFixedConnectionTabs(current);
+            this.ReplaceConnection(current, replacement);
+        }
+
+        private void ReplaceConnection(ConnectionInfo current, ConnectionInfo replacement)
+        {
+            IEnumerable<IConnectionTab> connectionTabs = this.GetAllControlsOnTabs<IConnectionTab>()
+                .Where(t => t.ConnectionInfo == current && t.AllowsChangeConnection);
+
+            foreach (var tab in connectionTabs)
+            {
+                tab.ConnectionInfo = replacement;
+            }
         }
 
         private void CloseAllFixedConnectionTabs(ConnectionInfo connection)
@@ -289,6 +296,13 @@ namespace SwqlStudio
             return connectionTab != null && 
                    connectionTab.ConnectionInfo == connection &&
                    !connectionTab.AllowsChangeConnection;
+        }
+
+        private IEnumerable<TControl> GetAllControlsOnTabs<TControl>()
+        {
+            return from t in this.Contents.OfType<DockContent>()
+                from c in t.Controls.OfType<TControl>()
+                select c;
         }
     }
 }

--- a/Src/SwqlStudio/QueriesDockPanel.cs
+++ b/Src/SwqlStudio/QueriesDockPanel.cs
@@ -260,6 +260,7 @@ namespace SwqlStudio
         internal void CloseServer(ConnectionInfo connection)
         {
             this.objectExplorer.CloseServer(connection);
+            this.CloseAllFixedConnectionTabs(connection);
         }
 
         internal void RefreshServer(ConnectionInfo connection)
@@ -267,7 +268,7 @@ namespace SwqlStudio
             this.objectExplorer.RefreshServer(connection);
         }
 
-        internal void CloseAllFixedConnectionTabs(ConnectionInfo connection)
+        private void CloseAllFixedConnectionTabs(ConnectionInfo connection)
         {
             var toClose =this.Contents.OfType<DockContent>()
                 .Where(t => IsFixedConnectionTab(t, connection))

--- a/Src/SwqlStudio/QueriesDockPanel.cs
+++ b/Src/SwqlStudio/QueriesDockPanel.cs
@@ -264,7 +264,7 @@ namespace SwqlStudio
             this.ReplaceConnection(current, replacement);
         }
 
-        private void ReplaceConnection(ConnectionInfo current, ConnectionInfo replacement)
+        internal void ReplaceConnection(ConnectionInfo current, ConnectionInfo replacement)
         {
             IEnumerable<IConnectionTab> connectionTabs = this.GetAllControlsOnTabs<IConnectionTab>()
                 .Where(t => t.ConnectionInfo == current && t.AllowsChangeConnection);

--- a/Src/SwqlStudio/QueryStatusBar.cs
+++ b/Src/SwqlStudio/QueryStatusBar.cs
@@ -4,8 +4,10 @@ using System.Windows.Forms;
 
 namespace SwqlStudio
 {
-    class QueryStatusBar : StatusStrip
+    internal class QueryStatusBar : StatusStrip
     {
+        private const string NotAvailable = "N/A";
+
         private readonly ToolStripStatusLabel _connectionLabel;
         private readonly ToolStripStatusLabel _serverLabel;
         private readonly ToolStripStatusLabel _userLabel;
@@ -45,13 +47,22 @@ namespace SwqlStudio
             }
         }
 
-        public void Initialize(string serverName, string userName)
+        public void Initialize(ConnectionInfo connection)
         {
             Items.AddRange(AllLabels);
 
-            _connectionLabel.Text = "Connected";
-            _serverLabel.Text = String.Format("Server: {0}", serverName);
-            _userLabel.Text = String.Format("User: {0}", userName);
+            if (connection != null)
+            {
+                _connectionLabel.Text = "Connected";
+                _serverLabel.Text = String.Format("Server: {0}", connection.Server);
+                _userLabel.Text = String.Format("User: {0}", connection.UserName);
+            }
+            else
+            {
+                _connectionLabel.Text = NotAvailable;
+                _serverLabel.Text = NotAvailable;
+                _userLabel.Text = NotAvailable;
+            }
 
             UpdateValues(0, TimeSpan.Zero);
         }

--- a/Src/SwqlStudio/QueryTab.cs
+++ b/Src/SwqlStudio/QueryTab.cs
@@ -17,7 +17,7 @@ using SwqlStudio.Subscriptions;
 
 namespace SwqlStudio
 {
-    public partial class QueryTab : UserControl, IConnectionTab
+    public partial class QueryTab : TabTemplate, IConnectionTab
     {
         private readonly CachedParameters preserved = new CachedParameters();
 
@@ -28,7 +28,17 @@ namespace SwqlStudio
             get { return !String.IsNullOrEmpty(subscriptionId); }
         }
         
-        public bool AllowsChangeConnection => !this.HasSubscription;
+        public override bool AllowsChangeConnection => !this.HasSubscription;
+
+        public override ConnectionInfo ConnectionInfo
+        {
+            get { return base.ConnectionInfo; }
+            set
+            {
+                base.ConnectionInfo = value;
+                queryStatusBar1.Initialize(base.ConnectionInfo);
+            }
+        }
 
         [Flags]
         enum Tabs
@@ -119,17 +129,6 @@ namespace SwqlStudio
             this.sciTextEditorControl1.SetSavePoint();
         }
 
-        private ConnectionInfo connectionInfo;
-
-        public ConnectionInfo ConnectionInfo
-        {
-            get { return connectionInfo; }
-            set
-            {
-                connectionInfo = value;
-                queryStatusBar1.Initialize(connectionInfo.Server, connectionInfo.UserName);
-            }
-        }
 
         internal SciTextEditorControl Editor { get { return sciTextEditorControl1; } }
 
@@ -728,6 +727,9 @@ namespace SwqlStudio
 
         private void deleteToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            if (ConnectionInfo == null)
+                return;
+
             var errors = new StringBuilder();
             var deletedRows = new List<DataGridViewRow>();
             foreach (DataGridViewRow row in dataGridView1.SelectedRows)
@@ -735,7 +737,7 @@ namespace SwqlStudio
                 try
                 {
                     var uri = (string)row.Cells["Uri"].Value;
-                    ConnectionInfo.DoWithExceptionTranslation(() => connectionInfo.Proxy.Delete(uri));
+                    ConnectionInfo.DoWithExceptionTranslation(() => ConnectionInfo.Proxy.Delete(uri));
                     deletedRows.Add(row);
                 }
                 catch (Exception ex)

--- a/Src/SwqlStudio/ServerList.cs
+++ b/Src/SwqlStudio/ServerList.cs
@@ -1,19 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SwqlStudio
 {
-    internal class ConnectionsEventArgs : EventArgs
-    {
-        internal ConnectionInfo Connection { get; private set; }
-
-        public ConnectionsEventArgs(ConnectionInfo connection)
-        {
-            this.Connection = connection;
-        }
-    }
-
     internal class ServerList
     {
         internal delegate void ConnectionsEventHandler(object sender, ConnectionsEventArgs e);
@@ -22,23 +11,18 @@ namespace SwqlStudio
         private readonly Dictionary<ConnectionInfo, IMetadataProvider> metadataProviders =
             new Dictionary<ConnectionInfo, IMetadataProvider>();
 
-        internal List<ConnectionInfo> Connections
-        {
-            get { return this.connections.Values.ToList(); }
-        }
-
-        public event EventHandler ConnectionsChanged;
+        public event ConnectionsEventHandler ConnectionAdded;
 
         public event ConnectionsEventHandler ConnectionRemoved;
 
-        public IMetadataProvider Add(ConnectionInfo connection)
+        public void Add(ConnectionInfo connection)
         {
             string key = GetKey(connection);
             connections.Add(key, connection);
             var provider = new SwisMetaDataProvider(connection);
             metadataProviders[connection] = provider;
-            ConnectionsChanged(this, EventArgs.Empty);
-            return provider;
+            var e = new ConnectionsEventArgs(connection);
+            ConnectionAdded(this, e);
         }
 
         public void Remove(ConnectionInfo connection)

--- a/Src/SwqlStudio/ServerList.cs
+++ b/Src/SwqlStudio/ServerList.cs
@@ -4,8 +4,19 @@ using System.Linq;
 
 namespace SwqlStudio
 {
+    internal class ConnectionsEventArgs : EventArgs
+    {
+        internal ConnectionInfo Connection { get; private set; }
+
+        public ConnectionsEventArgs(ConnectionInfo connection)
+        {
+            this.Connection = connection;
+        }
+    }
+
     internal class ServerList
     {
+        internal delegate void ConnectionsEventHandler(object sender, ConnectionsEventArgs e);
         private readonly Dictionary<string, ConnectionInfo> connections = new Dictionary<string, ConnectionInfo>();
 
         private readonly Dictionary<ConnectionInfo, IMetadataProvider> metadataProviders =
@@ -17,6 +28,8 @@ namespace SwqlStudio
         }
 
         public event EventHandler ConnectionsChanged;
+
+        public event ConnectionsEventHandler ConnectionRemoved;
 
         public IMetadataProvider Add(ConnectionInfo connection)
         {
@@ -33,7 +46,8 @@ namespace SwqlStudio
             string key = GetKey(connection);
             connections.Remove(key);
             metadataProviders.Remove(connection);
-            ConnectionsChanged(this, EventArgs.Empty);
+            var e = new ConnectionsEventArgs(connection);
+            ConnectionRemoved(this, e);
         }
 
         public bool Exists(ConnectionInfo connection)

--- a/Src/SwqlStudio/SwqlStudio.csproj
+++ b/Src/SwqlStudio/SwqlStudio.csproj
@@ -126,6 +126,7 @@
     <Compile Include="CachedParameters.cs" />
     <Compile Include="ConnectionHistory.cs" />
     <Compile Include="ConnectionInfo.cs" />
+    <Compile Include="ConnectionsEventArgs.cs" />
     <Compile Include="ConnectionsManager.cs" />
     <Compile Include="Controls\TabControlEx.cs">
       <SubType>Component</SubType>

--- a/Src/SwqlStudio/SwqlStudio.csproj
+++ b/Src/SwqlStudio/SwqlStudio.csproj
@@ -235,6 +235,9 @@
       <DependentUpon>SubscriptionTab.cs</DependentUpon>
     </Compile>
     <Compile Include="TabsFactory.cs" />
+    <Compile Include="TabTemplate.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="Utility.cs" />
     <Compile Include="Utils\CommandLineGenerator.cs" />
     <Compile Include="Utils\Win32.cs" />

--- a/Src/SwqlStudio/TabTemplate.cs
+++ b/Src/SwqlStudio/TabTemplate.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows.Forms;
+
+namespace SwqlStudio
+{
+    public abstract class TabTemplate : UserControl
+    {
+        private ConnectionInfo connection;
+
+        public virtual ConnectionInfo ConnectionInfo
+        {
+            get { return connection; }
+            set
+            {
+                if (this.AllowsChangeConnection)
+                    connection = value;
+            }
+        }
+
+        public virtual bool AllowsChangeConnection
+        {
+            get { return true; }
+        }
+    }
+}


### PR DESCRIPTION
Mostly refactorings to merge reactions on added or removed connections to one place. To be able do all UI refreshes in sync.
The main change is that Tabs, where it is possible to change connection may have connection assigned to null in case last connection was removed. But where not possible the tab needs to be closed.