### PR TITLE
Query autocomplete fixes

### DIFF
--- a/Src/SwqlStudio/ActivityMonitorTab.cs
+++ b/Src/SwqlStudio/ActivityMonitorTab.cs
@@ -7,19 +7,18 @@ namespace SwqlStudio
     public partial class ActivityMonitorTab : TabTemplate, IConnectionTab
     {
         private string subscriptionId;
-        private bool conneciotnSet = false;
+        private bool connectionSet;
 
         public SubscriptionManager SubscriptionManager { get; set; }
 
-        public override bool AllowsChangeConnection => !this.conneciotnSet;
+        public override bool AllowsChangeConnection => !this.connectionSet;
 
         public override ConnectionInfo ConnectionInfo
         {
-            get { return base.ConnectionInfo; }
             set
             {
                 base.ConnectionInfo = value;
-                this.conneciotnSet = true;
+                this.connectionSet = true;
             }
         }
 

--- a/Src/SwqlStudio/QueryTab.cs
+++ b/Src/SwqlStudio/QueryTab.cs
@@ -17,7 +17,7 @@ using SwqlStudio.Subscriptions;
 
 namespace SwqlStudio
 {
-    public partial class QueryTab : TabTemplate, IConnectionTab
+    public sealed partial class QueryTab : TabTemplate, IConnectionTab
     {
         private readonly CachedParameters preserved = new CachedParameters();
 
@@ -35,6 +35,7 @@ namespace SwqlStudio
             set
             {
                 base.ConnectionInfo = value;
+                SetMetadataProvider();
                 queryStatusBar1.Initialize(base.ConnectionInfo);
             }
         }
@@ -52,8 +53,9 @@ namespace SwqlStudio
         }
 
         private Font nullFont;
-        public IApplicationService ApplicationService { get; set; }
-        public SubscriptionManager SubscriptionManager { get; set; }
+        private IApplicationService ApplicationService { get; }
+        private SubscriptionManager SubscriptionManager { get; }
+        private ServerList ServerList { get; }
 
         public QueryTab()
         {
@@ -62,6 +64,14 @@ namespace SwqlStudio
             ShowTabs(Tabs.Results);
             Disposed += QueryTabDisposed;
             AddRunContextMenu();
+        }
+
+        internal QueryTab(IApplicationService applicationService, ServerList serverList, ConnectionInfo connectionInfo, SubscriptionManager subscriptionManager) : this()
+        {
+            ApplicationService = applicationService;
+            ServerList = serverList;
+            ConnectionInfo = connectionInfo;
+            SubscriptionManager = subscriptionManager;
         }
 
         private void AddRunContextMenu()
@@ -756,9 +766,13 @@ namespace SwqlStudio
             deleteToolStripMenuItem.Enabled = dataGridView1.Columns.Contains("Uri") && dataGridView1.SelectedRows.Count > 0;
         }
 
-        internal void SetMetadataProvider(IMetadataProvider provider)
+        private void SetMetadataProvider()
         {
-            sciTextEditorControl1.SetMetadata(provider);
+            IMetadataProvider provider;
+            if (ServerList != null && ConnectionInfo != null && ServerList.TryGetProvider(ConnectionInfo, out provider))
+            {
+                sciTextEditorControl1.SetMetadata(provider);
+            }
         }
 
         private void sciTextEditorControl1_TextChanged(object sender, EventArgs e)

--- a/Src/SwqlStudio/QueryTab.cs
+++ b/Src/SwqlStudio/QueryTab.cs
@@ -32,7 +32,6 @@ namespace SwqlStudio
 
         public override ConnectionInfo ConnectionInfo
         {
-            get { return base.ConnectionInfo; }
             set
             {
                 base.ConnectionInfo = value;

--- a/Src/SwqlStudio/SciTextEditorControl.cs
+++ b/Src/SwqlStudio/SciTextEditorControl.cs
@@ -228,5 +228,11 @@ namespace SwqlStudio
         }
 
         string ILexerDataSource.Text => this.Text;
+
+        protected override void Dispose(bool disposing)
+        {
+            LexerService.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Src/SwqlStudio/ServerList.cs
+++ b/Src/SwqlStudio/ServerList.cs
@@ -22,7 +22,7 @@ namespace SwqlStudio
             var provider = new SwisMetaDataProvider(connection);
             metadataProviders[connection] = provider;
             var e = new ConnectionsEventArgs(connection);
-            ConnectionAdded(this, e);
+            ConnectionAdded?.Invoke(this, e);
         }
 
         public void Remove(ConnectionInfo connection)
@@ -31,7 +31,7 @@ namespace SwqlStudio
             connections.Remove(key);
             metadataProviders.Remove(connection);
             var e = new ConnectionsEventArgs(connection);
-            ConnectionRemoved(this, e);
+            ConnectionRemoved?.Invoke(this, e);
         }
 
         public bool Exists(ConnectionInfo connection)

--- a/Src/SwqlStudio/TabTemplate.cs
+++ b/Src/SwqlStudio/TabTemplate.cs
@@ -2,7 +2,7 @@
 
 namespace SwqlStudio
 {
-    public abstract class TabTemplate : UserControl
+    public class TabTemplate : UserControl
     {
         private ConnectionInfo connection;
 

--- a/Src/SwqlStudio/TabsFactory.cs
+++ b/Src/SwqlStudio/TabsFactory.cs
@@ -206,17 +206,11 @@ namespace SwqlStudio
 
         private QueryTab CreateQueryTab(string title, ConnectionInfo info)
         {
-            var queryTab = new QueryTab
+            var queryTab = new QueryTab(applicationService, serverList, info, applicationService.SubscriptionManager)
             {
-                ConnectionInfo = info,
-                Dock = DockStyle.Fill,
-                ApplicationService = this.applicationService,
-                SubscriptionManager = this.applicationService.SubscriptionManager
+                Dock = DockStyle.Fill
             };
-            
-            IMetadataProvider provider;
-            this.serverList.TryGetProvider(info, out provider);
-            queryTab.SetMetadataProvider(provider);
+
             AddNewTab(queryTab, title);
             return queryTab;
         }


### PR DESCRIPTION
The recent addition of an option to change connections used in query tabs did not count with the autocomplete feature. The autocomplete list was not updated when a connection changed. This pull request fixes this and a few other issues (memory leak, designer view, ...).