### PR TITLE
Fixed notification not received in SWQL studio

### DIFF
--- a/Src/SwqlStudio/ActivityMonitorTab.cs
+++ b/Src/SwqlStudio/ActivityMonitorTab.cs
@@ -32,7 +32,7 @@ namespace SwqlStudio
         {
             if (!String.IsNullOrEmpty(subscriptionId) && ConnectionInfo.IsConnected)
             {
-                this.SubscriptionManager.Unsubscribe(ConnectionInfo, subscriptionId);
+                this.SubscriptionManager.Unsubscribe(ConnectionInfo, subscriptionId, SubscriptionIndicationReceived);
             }
         }
 
@@ -69,7 +69,8 @@ namespace SwqlStudio
             backgroundWorker1.ReportProgress(0, "Starting subscription...");
             try
             {
-                subscriptionId = this.SubscriptionManager.CreateSubscription(ConnectionInfo, "SUBSCRIBE System.QueryExecuted", SubscriptionIndicationReceived);
+                subscriptionId = this.SubscriptionManager
+                    .CreateSubscription(ConnectionInfo, "SUBSCRIBE System.QueryExecuted", SubscriptionIndicationReceived);
                 backgroundWorker1.ReportProgress(0, "Waiting for notifications");
             }
             catch (ApplicationException ex)

--- a/Src/SwqlStudio/QueryTab.cs
+++ b/Src/SwqlStudio/QueryTab.cs
@@ -103,7 +103,7 @@ namespace SwqlStudio
         {
             if (HasSubscription)
             {
-                this.SubscriptionManager.Unsubscribe(ConnectionInfo, subscriptionId);
+                this.SubscriptionManager.Unsubscribe(ConnectionInfo, subscriptionId, SubscriptionIndicationReceived);
                 this.subscriptionId = string.Empty;
             }
         }
@@ -705,7 +705,8 @@ namespace SwqlStudio
 
             try
             {
-                subscriptionId = this.SubscriptionManager.CreateSubscription(ConnectionInfo, arg.Query, SubscriptionIndicationReceived);
+                subscriptionId = this.SubscriptionManager
+                    .CreateSubscription(ConnectionInfo, arg.Query, SubscriptionIndicationReceived);
                 this.Invoke(new Action(() => this.ApplicationService.RefreshSelectedConnections()));
                 subscriptionWorker.ReportProgress(0, "Waiting for notifications");
             }

--- a/Src/SwqlStudio/Subscriptions/SubscriptionCallbacks.cs
+++ b/Src/SwqlStudio/Subscriptions/SubscriptionCallbacks.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace SwqlStudio.Subscriptions
+{
+    internal class SubscriptionCallbacks
+    {
+        private readonly string activeSubscriberAddress;
+        internal string Uri { get; }
+        internal string Id { get; set; }
+
+        private readonly NotificationDeliveryServiceProxy proxy;
+
+        internal IEnumerable<SubscriberCallback> Callbacks => this.callbacks;
+        public bool Empty => !this.callbacks.Any();
+
+        private readonly List<SubscriberCallback> callbacks = new List<SubscriberCallback>();
+
+        public SubscriptionCallbacks(string uri, NotificationDeliveryServiceProxy proxy, string activeSubscriberAddress)
+        {
+            this.Uri = uri;
+            this.Id = uri.Substring(uri.LastIndexOf("=") + 1);
+            this.proxy = proxy;
+            this.activeSubscriberAddress = activeSubscriberAddress;
+        }
+
+        internal void Add(SubscriberCallback callback)
+        {
+            if (!this.callbacks.Contains(callback))
+                this.callbacks.Add(callback);
+        }
+
+        internal void Remove(SubscriberCallback callback)
+        {
+            this.callbacks.Remove(callback);
+        }
+
+        internal void CloseProxy()
+        {
+            if (this.proxy != null)
+            {
+                this.proxy.Disconnect(this.activeSubscriberAddress);
+                this.proxy.Close();
+            }
+        }
+    }
+}

--- a/Src/SwqlStudio/Subscriptions/SubscriptionInfo.cs
+++ b/Src/SwqlStudio/Subscriptions/SubscriptionInfo.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SwqlStudio.Subscriptions
+{
+    internal class SubscriptionInfo
+    {
+        private readonly ConnectionInfo connection;
+
+        private readonly ConcurrentDictionary<string, SubscriptionCallbacks> subscriptions =
+            new ConcurrentDictionary<string, SubscriptionCallbacks>();
+
+        internal SubscriptionInfo(ConnectionInfo connection)
+        {
+            this.connection = connection;
+        }
+
+        internal bool HasSubScription(string subscriptionId)
+        {
+            return this.subscriptions.Values.Any(s => s.Id == subscriptionId);
+        }
+
+        internal string Register(string query, SubscriberCallback callback,
+            Func<ConnectionInfo, string, SubscriptionCallbacks> subscribe)
+        {
+            SubscriptionCallbacks subscription;
+            var normalized = query.ToLower();
+
+            if (!this.subscriptions.TryGetValue(normalized, out subscription))
+            {
+                subscription = subscribe(this.connection, query);
+                this.subscriptions.TryAdd(normalized, subscription);
+            }
+
+            subscription.Add(callback);
+            return subscription.Uri;
+        }
+
+        internal void Remove(string subscriptionUri, SubscriberCallback callback)
+        {
+            var query = this.subscriptions.Where(kv => kv.Value.Uri == subscriptionUri)
+                .Select(kv => kv.Key)
+                .FirstOrDefault();
+
+            if (String.IsNullOrEmpty(query))
+                return;
+                
+            var subscription = this.subscriptions[query];
+            subscription.Remove(callback);
+
+            if (subscription.Empty)
+            {
+                this.subscriptions.TryRemove(query, out subscription);
+                this.Unsubscribe(subscriptionUri);
+                subscription.CloseProxy();
+            }
+        }
+
+        private void Unsubscribe(string subscriptionUri)
+        {
+            if (this.connection.IsConnected)
+                this.connection.Proxy.Delete(subscriptionUri);
+        }
+
+        internal IEnumerable<SubscriberCallback> CallBacks(string subscriptionId)
+        {
+            return this.subscriptions.Values.Where(v => v.Id == subscriptionId)
+                .SelectMany(kv => kv.Callbacks)
+                .ToList();
+        }
+    }
+}

--- a/Src/SwqlStudio/SwqlStudio.csproj
+++ b/Src/SwqlStudio/SwqlStudio.csproj
@@ -226,6 +226,8 @@
     <Compile Include="ServerList.cs" />
     <Compile Include="ServerType.cs" />
     <Compile Include="Subscription.cs" />
+    <Compile Include="Subscriptions\SubscriptionCallbacks.cs" />
+    <Compile Include="Subscriptions\SubscriptionInfo.cs" />
     <Compile Include="Subscriptions\SubscriptionManager.cs" />
     <Compile Include="Subscriptions\SubscriptionServiceHost.cs" />
     <Compile Include="SubscriptionTab.cs">


### PR DESCRIPTION
**Steps to reproduce:**
1. Connect SWQL studio via certificate
2. Create subscription tab (by right click on required entity, e.g. "SUBSCRIBE CHANGES TO SUBSCRIBE CHANGES TO Orion.Nodes") and Execute the query (Now the tab is waiting for notifications)
3. Modify the entity and observe received notification
4. Close the tab
5. Repeat steps 2. and 3. to recreate the tab with already closed subscription

**Actual result:**
* Notifications are no longer received for the same query, you need to close the SWQL studio
* The same issue happens, when multiple tabs are opened trying to receive the same notifications. Only first tab receives the notifications

**Expected result:**
* Notifications are received to all windows registered to listen for notifications