### PR TITLE
Dev/is/fix log copypaste

### DIFF
--- a/Src/SwqlStudio/QueryTab.Designer.cs
+++ b/Src/SwqlStudio/QueryTab.Designer.cs
@@ -307,6 +307,7 @@ namespace SwqlStudio
             this.logTextbox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.logTextbox.Size = new System.Drawing.Size(466, 206);
             this.logTextbox.TabIndex = 0;
+            this.logTextbox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.logTextbox_KeyDown);
             // 
             // notificationTab
             // 

--- a/Src/SwqlStudio/QueryTab.cs
+++ b/Src/SwqlStudio/QueryTab.cs
@@ -854,7 +854,7 @@ namespace SwqlStudio
         {
             // a bit ugly, but considering the fact that CTRL+A doesn't work
             // if TextBox is multiline...
-            // https://stackoverflow.com/questions/435433/what-is-the-preferred-way-to-find-focused-control-in-winforms-app
+            // https://msdn.microsoft.com/en-us/library/system.windows.forms.textboxbase.shortcutsenabled(v=vs.100).aspx
             if (e.Control && e.KeyCode == Keys.A)
             {
                 if (sender != null)

--- a/Src/SwqlStudio/QueryTab.cs
+++ b/Src/SwqlStudio/QueryTab.cs
@@ -205,6 +205,31 @@ namespace SwqlStudio
             {
                 CopyActiveGridCellToClipboard(dataGridView1);
             }
+            else
+            {
+                // if none of previous cases worked, try to find active control and copy contents of it
+                var activeControl = FindFocusedControl(this);
+                HandleCopyEventForActiveControl(activeControl);
+            }          
+        }
+
+        private void HandleCopyEventForActiveControl(Control activeControl)
+        {
+            if (activeControl is TextBox)
+            {
+                ((TextBox)activeControl).Copy();
+            }
+        }
+
+        private Control FindFocusedControl(Control control)
+        {
+            var container = control as IContainerControl;
+            while (container != null)
+            {
+                control = container.ActiveControl;
+                container = control as IContainerControl;
+            }
+            return control;
         }
 
         private void toolStripMenuItem2_Click(object sender, System.EventArgs e)
@@ -823,6 +848,18 @@ namespace SwqlStudio
         internal void Redo()
         {
             this.sciTextEditorControl1.Redo();
+        }
+
+        private void logTextbox_KeyDown(object sender, KeyEventArgs e)
+        {
+            // a bit ugly, but considering the fact that CTRL+A doesn't work
+            // if TextBox is multiline...
+            // https://stackoverflow.com/questions/435433/what-is-the-preferred-way-to-find-focused-control-in-winforms-app
+            if (e.Control && e.KeyCode == Keys.A)
+            {
+                if (sender != null)
+                    ((TextBox)sender).SelectAll();
+            }
         }
     }
 }


### PR DESCRIPTION
Current version of SWQL Studio doesn't allow to copy contents of ``Log`` tab in case ``WITH LOGS`` clause is used. This is due to custom implementation of handling copy event, 

This PR fixes this issue and allows:
1) use CTRL+ A to perform Select All
2) use CTRL+ C to copy selected content