### PR TITLE
Added support of parameters to Copy Query As -> Get-Swis-Data command

### DIFF
--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -459,14 +459,15 @@ namespace SwqlStudio
             CopyQueryAs(CommandLineGenerator.GetQueryForPowerShellGetSwisData);
         }
 
-        private void CopyQueryAs(Func<string, ConnectionInfo, string> formatter)
+        private void CopyQueryAs(Func<string, ConnectionInfo, PropertyBag, string> formatter)
         {
             var connection = filesDock.ActiveConnectionTab?.ConnectionInfo;
             if (connection == null)
                 return;
 
             var query = filesDock.ActiveQueryTab.QueryText;
-            string command = formatter(query, connection);
+            var parameters = filesDock.QueryParameters;
+            string command = formatter(query, connection, parameters);
             Clipboard.SetText(command);
         }
 

--- a/Src/SwqlStudio/Utils/CommandLineGenerator.cs
+++ b/Src/SwqlStudio/Utils/CommandLineGenerator.cs
@@ -41,10 +41,10 @@ namespace SwqlStudio.Utils
                 decimal tempNum = 0;
                 currentParameterIndex++;
                 var isNumber = decimal.TryParse(param.Value.ToString(), out tempNum);
-                var format = "{0}='{1}'";
+                var format = "{0}={1}";
                 var isLastElement = currentParameterIndex == parametersCount;
                 format = isLastElement ? format : string.Concat(format, ";");
-                result.Append(string.Format(format, param.Key, param.Value));
+                result.Append(string.Format(format, param.Key, QuoteForPowerShell(param.Value.ToString())));
             }
 
             return string.Format("@{{{0}}}", result.ToString());

--- a/Src/SwqlStudio/Utils/CommandLineGenerator.cs
+++ b/Src/SwqlStudio/Utils/CommandLineGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using SolarWinds.InformationService.Contract2;
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -33,21 +34,11 @@ namespace SwqlStudio.Utils
 
         private static string GetParamsObjectInPowershellFormat(PropertyBag parameters)
         {
-            var result = new StringBuilder();
-            var parametersCount = parameters.Count;
-            var currentParameterIndex = 0;
-            foreach (var param in parameters)
-            {
-                decimal tempNum = 0;
-                currentParameterIndex++;
-                var isNumber = decimal.TryParse(param.Value.ToString(), out tempNum);
-                var format = "{0}={1}";
-                var isLastElement = currentParameterIndex == parametersCount;
-                format = isLastElement ? format : string.Concat(format, ";");
-                result.Append(string.Format(format, param.Key, QuoteForPowerShell(param.Value.ToString())));
-            }
+            var parametersSerialized = string.Join(
+                ";", 
+                parameters.Select(x => string.Format("{0}={1}", x.Key, QuoteForPowerShell(x.Value.ToString()))));
 
-            return string.Format("@{{{0}}}", result.ToString());
+            return string.Format("@{{{0}}}", parametersSerialized.ToString());
         }
 
         private static string GetUrlForQuery(string query, ConnectionInfo connection)


### PR DESCRIPTION
Related to [**this**](https://github.com/solarwinds/OrionSDK/issues/145) issue. Changed logic so that parameters also get passed to Get-Swis-Data Powershell command. Haven't implemented this for CURL because as far as I aware, SWIS doesn't allow execute query and pass parameters via REST API endpoint (``https://[swis-address]:17778/SolarWinds/InformationService/v3/Json/Query?query=[query]``).