### PR TITLE
Fixed application crash, while unsubscribing notifications

### DIFF
--- a/Src/SwqlStudio/Subscriptions/SubscriptionManager.cs
+++ b/Src/SwqlStudio/Subscriptions/SubscriptionManager.cs
@@ -41,6 +41,11 @@ namespace SwqlStudio.Subscriptions
             {
                 log.Debug($"Unable to unsubscribe {subscriptionUri}.  Must have been deleted already", ex);
             }
+            catch (CommunicationException ex)
+            {
+                // also in case connection already disposed
+                log.Debug("Unable to unsubscribe due to communication error.", ex);
+            }
         }
 
         public string CreateSubscription(ConnectionInfo connectionInfo, string subscriptionQuery, SubscriberCallback callback)


### PR DESCRIPTION
When closing tab with subscription, the app crashed, if the connection wasn't available.
This only hides the exception, since there is nothing more we can do.
We should also consider to make it more stable against socket exceptions, since still other kind of exceptions are possible (e.g. TimeOutException).

Call stack:
System.ServiceModel.CommunicationException: The socket connection was aborted. This could be caused by an error processing your message or a receive timeout being exceeded by the remote host, or an underlying network resource issue. Local socket timeout was '00:02:00'. ---> System.IO.IOException: The write operation failed, see inner exception. ---> System.ServiceModel.CommunicationException: The socket connection was aborted. This could be caused by an error processing your message or a receive timeout being exceeded by the remote host, or an underlying network resource issue. Local socket timeout was '00:02:00'. ---> System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host
   at System.Net.Sockets.Socket.Send(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags)
   at System.ServiceModel.Channels.SocketConnection.Write(Byte[] buffer, Int32 offset, Int32 size, Boolean immediate, TimeSpan timeout)
   --- End of inner exception stack trace ---
   at System.ServiceModel.Channels.SocketConnection.Write(Byte[] buffer, Int32 offset, Int32 size, Boolean immediate, TimeSpan timeout)
   at System.ServiceModel.Channels.BufferedConnection.WriteNow(Byte[] buffer, Int32 offset, Int32 size, TimeSpan timeout, BufferManager bufferManager)
   at System.ServiceModel.Channels.BufferedConnection.Write(Byte[] buffer, Int32 offset, Int32 size, Boolean immediate, TimeSpan timeout)
   at System.ServiceModel.Channels.ConnectionStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at System.Net.Security._SslStream.StartWriting(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security._SslStream.ProcessWrite(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   --- End of inner exception stack trace ---
   at System.Net.Security._SslStream.ProcessWrite(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at System.ServiceModel.Channels.StreamConnection.Write(Byte[] buffer, Int32 offset, Int32 size, Boolean immediate, TimeSpan timeout)
   --- End of inner exception stack trace ---

Server stack trace: 
   at System.ServiceModel.Channels.StreamConnection.Write(Byte[] buffer, Int32 offset, Int32 size, Boolean immediate, TimeSpan timeout)
   at System.ServiceModel.Channels.StreamConnection.Write(Byte[] buffer, Int32 offset, Int32 size, Boolean immediate, TimeSpan timeout, BufferManager bufferManager)
   at System.ServiceModel.Channels.FramingDuplexSessionChannel.OnSendCore(Message message, TimeSpan timeout)
   at System.ServiceModel.Channels.TransportDuplexSessionChannel.OnSend(Message message, TimeSpan timeout)
   at System.ServiceModel.Channels.OutputChannel.Send(Message message, TimeSpan timeout)
   at System.ServiceModel.Dispatcher.DuplexChannelBinder.Request(Message message, TimeSpan timeout)
   at System.ServiceModel.Channels.ServiceChannel.Call(String action, Boolean oneway, ProxyOperationRuntime operation, Object[] ins, Object[] outs, TimeSpan timeout)
   at System.ServiceModel.Channels.ServiceChannelProxy.InvokeService(IMethodCallMessage methodCall, ProxyOperationRuntime operation)
   at System.ServiceModel.Channels.ServiceChannelProxy.Invoke(IMessage message)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at SolarWinds.InformationService.Contract2.IInformationService.Delete(String uri)
   at SolarWinds.InformationService.Contract2.InfoServiceProxy.Delete(String uri) in C:\Workspaces\OrionSdk_GitHub\Src\Contract\InfoServiceProxy.cs:line 371
   at SwqlStudio.Subscriptions.SubscriptionInfo.Unsubscribe(String subscriptionUri) in C:\Workspaces\OrionSdk_GitHub\Src\SwqlStudio\Subscriptions\SubscriptionInfo.cs:line 64
   at SwqlStudio.Subscriptions.SubscriptionInfo.Remove(String subscriptionUri, SubscriberCallback callback) in C:\Workspaces\OrionSdk_GitHub\Src\SwqlStudio\Subscriptions\SubscriptionInfo.cs:line 56
   at SwqlStudio.Subscriptions.SubscriptionManager.Unsubscribe(ConnectionInfo connectionInfo, String subscriptionUri, SubscriberCallback callback) in C:\Workspaces\OrionSdk_GitHub\Src\SwqlStudio\Subscriptions\SubscriptionManager.cs:line 37
   at SwqlStudio.QueryTab.Unsubscribe() in C:\Workspaces\OrionSdk_GitHub\Src\SwqlStudio\QueryTab.cs:line 106
   at SwqlStudio.QueryTab.QueryTabDisposed(Object sender, EventArgs e) in C:\Workspaces\OrionSdk_GitHub\Src\SwqlStudio\QueryTab.cs:line 99
   at System.ComponentModel.Component.Dispose(Boolean disposing)
   at System.Windows.Forms.Control.Dispose(Boolean disposing)
   at System.Windows.Forms.ContainerControl.Dispose(Boolean disposing)
   at SwqlStudio.QueryTab.Dispose(Boolean disposing) in C:\Workspaces\OrionSdk_GitHub\Src\SwqlStudio\QueryTab.Designer.cs:line 23
   at System.ComponentModel.Component.Dispose()
   at System.Windows.Forms.Control.Dispose(Boolean disposing)
   at System.Windows.Forms.Form.Dispose(Boolean disposing)
   at System.Windows.Forms.Form.WmClose(Message& m)
   at System.Windows.Forms.Form.WndProc(Message& m)
   at System.Windows.Forms.Control.ControlNativeWindow.OnMessage(Message& m)
   at System.Windows.Forms.Control.ControlNativeWindow.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)