### PR TITLE
Allowed port in new connection dialog server text box

### DIFF
--- a/Src/SwqlStudio/InfoServiceBase.cs
+++ b/Src/SwqlStudio/InfoServiceBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.ServiceModel.Channels;
 using SolarWinds.InformationService.Contract2;
 using SolarWinds.InformationService.Contract2.PubSub;
@@ -44,8 +45,18 @@ namespace SwqlStudio
 
         public virtual Uri Uri(string serverAddress)
         {
-            Uri uri = new Uri(String.Format("{0}://{1}:{2}/" + _endpoint, _protocolName, serverAddress, Port));
-            return uri;
+            if (serverAddress.Contains(":"))
+            {
+                var parts = serverAddress.Split(':');
+                return Uri(parts[0], parts[1]);
+            }
+
+            return Uri(serverAddress, Port.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private Uri Uri(string serverAddress, string port)
+        {
+            return new Uri(String.Format("{0}://{1}:{2}/" + _endpoint, _protocolName, serverAddress, port));
         }
 
         public virtual InfoServiceProxy CreateProxy(string server)


### PR DESCRIPTION
Till now the port number was hard-coded, this pull request allows to override it from Connection dialog Server Name field using form `Host:PortNumber` e.g. "localhost:18763".
This is useful for PortableSwis and debugging.