### PR TITLE
Add Filtering based on obsolete metadata. Filtering code refactoring.

### DIFF
--- a/Src/SwqlStudio/MainForm.Designer.cs
+++ b/Src/SwqlStudio/MainForm.Designer.cs
@@ -93,6 +93,7 @@
             this.newFileToolButton = new System.Windows.Forms.ToolStripButton();
             this.openFileButton = new System.Windows.Forms.ToolStripButton();
             this.saveToolButton = new System.Windows.Forms.ToolStripButton();
+            this.showObsoleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.menu.SuspendLayout();
             this.mainToolbar.SuspendLayout();
@@ -398,7 +399,8 @@
             this.groupEntityTreeToolStripMenuItem,
             this.enableAutocompleteToolStripMenuItem,
             this.discoverQueryParametersMenuItem,
-            this.promptToSaveOnCloseToolStripMenuItem});
+            this.promptToSaveOnCloseToolStripMenuItem,
+            this.showObsoleteToolStripMenuItem});
             this.preferencesToolStripMenuItem.Name = "preferencesToolStripMenuItem";
             this.preferencesToolStripMenuItem.Size = new System.Drawing.Size(80, 20);
             this.preferencesToolStripMenuItem.Text = "&Preferences";
@@ -640,6 +642,13 @@
             this.saveToolButton.ToolTipText = "Save (Ctrl+S)";
             this.saveToolButton.Click += new System.EventHandler(this.menuFileSave_Click);
             // 
+            // showObsoleteToolStripMenuItem
+            // 
+            this.showObsoleteToolStripMenuItem.Name = "showObsoleteToolStripMenuItem";
+            this.showObsoleteToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
+            this.showObsoleteToolStripMenuItem.Text = "Show Obsolete";
+            this.showObsoleteToolStripMenuItem.Click += new System.EventHandler(this.showObsoleteToolStripMenuItem_Click);
+            // 
             // MainForm
             // 
             this.AllowDrop = true;
@@ -730,6 +739,7 @@
         private System.Windows.Forms.ToolStripMenuItem findToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
         private System.Windows.Forms.ToolStripMenuItem replaceToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showObsoleteToolStripMenuItem;
     }
 }
 

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -418,6 +418,7 @@ namespace SwqlStudio
         {
             enableAutocompleteToolStripMenuItem.Checked = Settings.Default.AutocompleteEnabled;
             promptToSaveOnCloseToolStripMenuItem.Checked = Settings.Default.PromptToSaveOnClose;
+            showObsoleteToolStripMenuItem.Checked = Settings.Default.ShowObsolete;
         }
 
         private void searchInTreeHotKeyToolStripMenuItem_Click(object sender, EventArgs e)
@@ -505,6 +506,13 @@ namespace SwqlStudio
                 return;
 
             activeTab.ReplaceDialog();
+        }
+
+        private void showObsoleteToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Settings.Default.ShowObsolete = !Settings.Default.ShowObsolete;
+            Settings.Default.Save();
+            filesDock.RefreshObjectExplorerFilters();
         }
     }
 }

--- a/Src/SwqlStudio/Metadata/Entity.cs
+++ b/Src/SwqlStudio/Metadata/Entity.cs
@@ -2,7 +2,7 @@
 
 namespace SwqlStudio.Metadata
 {
-    public class Entity
+    public class Entity : IObsoleteMetadata
     {
         private readonly List<Property> properties = new List<Property>();
         private readonly List<Verb> verbs = new List<Verb>();
@@ -12,6 +12,8 @@ namespace SwqlStudio.Metadata
         public string BaseType { get; set; }
         public bool IsIndication { get; set; }
         public bool IsAbstract { get; set; }
+        public bool IsObsolete { get; set; }
+        public string ObsolescenceReason { get; set; }
 
         public bool CanCreate { get; set; }
         public bool CanDelete { get; set; }

--- a/Src/SwqlStudio/Metadata/IObsoleteMetadata.cs
+++ b/Src/SwqlStudio/Metadata/IObsoleteMetadata.cs
@@ -1,0 +1,8 @@
+﻿namespace SwqlStudio.Metadata
+{
+    public interface IObsoleteMetadata
+    {
+        bool IsObsolete { get; set; }
+        string ObsolescenceReason { get; set; }
+    }
+}

--- a/Src/SwqlStudio/Metadata/Property.cs
+++ b/Src/SwqlStudio/Metadata/Property.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace SwqlStudio.Metadata
 {
-    public class Property : ITypedMetadata
+    public class Property : ITypedMetadata, IObsoleteMetadata
     {
         public string Name { get; set; }
         public string Type { get; set; }
@@ -9,5 +9,8 @@ namespace SwqlStudio.Metadata
         public bool IsInherited { get; set; }
         public bool IsKey { get; set; }
         public string Summary { get; set; }
+
+        public bool IsObsolete { get; set; }
+        public string ObsolescenceReason { get; set; }
     }
 }

--- a/Src/SwqlStudio/Metadata/Verb.cs
+++ b/Src/SwqlStudio/Metadata/Verb.cs
@@ -2,13 +2,16 @@
 
 namespace SwqlStudio.Metadata
 {
-    public class Verb
+    public class Verb : IObsoleteMetadata
     {
         private readonly List<VerbArgument> _arguments = new List<VerbArgument>();
 
         public string Name { get; set; }
         public string EntityName { get; set; }
         public string Summary { get; set; }
+
+        public bool IsObsolete { get; set; }
+        public string ObsolescenceReason { get; set; }
 
         public List<VerbArgument> Arguments
         {

--- a/Src/SwqlStudio/ObjectExplorer/DocumentationBuilder.cs
+++ b/Src/SwqlStudio/ObjectExplorer/DocumentationBuilder.cs
@@ -47,6 +47,7 @@ namespace SwqlStudio
         {
             var builder = new StringBuilder();
             builder.AppendName(verb.Name);
+            builder.AppendObsoleteSection(verb);
             builder.AppendSummaryParagraph(verb.Summary);
             var docs = builder.ToString();
             return new Documentation("Verb", docs);
@@ -58,6 +59,7 @@ namespace SwqlStudio
             builder.AppendName(entity.FullName);
             builder.Append($"Base type: {entity.BaseType}\r\n");
             builder.AppendAccessControl(provider.ConnectionInfo, entity);
+            builder.AppendObsoleteSection(entity);
             builder.AppendSummaryParagraph(entity.Summary);
             var docs = builder.ToString();
             return new Documentation("Entity", docs);
@@ -75,8 +77,10 @@ namespace SwqlStudio
 
         private static Documentation PropertyDocumentation(Property property)
         {
-            var docs = MetadataDocumentation(property);
-            return new Documentation("Property", docs);
+            var builder = new StringBuilder();
+            builder.Append(MetadataDocumentation(property));
+            builder.AppendObsoleteSection(property);
+            return new Documentation("Property", builder.ToString());
         }
 
         private static Documentation ProviderDocumentation(IMetadataProvider provider)
@@ -100,11 +104,21 @@ namespace SwqlStudio
             builder.AppendSummary(metadata.Summary);
             return builder.ToString();
         }
-        
+
+        public static string ToToolTip(ITypedMetadata metadata, IObsoleteMetadata obsoleteMetadata)
+        {
+            var builder = new StringBuilder();
+            builder.AppendSummary(metadata.Summary);
+            builder.AppendObsoleteSection(obsoleteMetadata);
+            return builder.ToString();
+        }
+
+
         public static string ToToolTip(ConnectionInfo connection, Entity entity)
         {
             var builder = new StringBuilder();
             builder.AppendSummary(entity.Summary);
+            builder.AppendObsoleteSection(entity);
             return builder.ToString();
         }
         
@@ -112,6 +126,7 @@ namespace SwqlStudio
         {
             var builder = new StringBuilder();
             builder.AppendSummary(verb.Summary);
+            builder.AppendObsoleteSection(verb);
             return builder.ToString();
         }
 

--- a/Src/SwqlStudio/ObjectExplorer/Filtering/INodeFilterStrategy.cs
+++ b/Src/SwqlStudio/ObjectExplorer/Filtering/INodeFilterStrategy.cs
@@ -1,0 +1,10 @@
+﻿using System.Windows.Forms;
+
+namespace SwqlStudio.Filtering
+{
+    internal interface INodeFilterStrategy
+    {
+        void Initialize(TreeNode node);
+        VisibilityStatus GetVisibility(TreeNode node);
+    }
+}

--- a/Src/SwqlStudio/ObjectExplorer/Filtering/NodeFilter.cs
+++ b/Src/SwqlStudio/ObjectExplorer/Filtering/NodeFilter.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using SwqlStudio.Metadata;
+using SwqlStudio.Properties;
+
+namespace SwqlStudio.Filtering
+{
+    internal class NodeFilter
+    {
+        private readonly List<INodeFilterStrategy> _filters = new List<INodeFilterStrategy>();
+        private const int _limitOfExpandedNodes = 5000;
+        private int _visibleNodesCount;
+
+        public NodeFilter(TreeView treeData, string filter)
+        {
+            InitializeFilters(treeData, filter);
+        }
+
+        private void InitializeFilters(TreeView treeData, string filter)
+        {
+            if (!Settings.Default.ShowObsolete)
+            {
+                _filters.Add(new ObsoleteNodeFilter());
+            }
+            if (filter != null)
+            {
+                _filters.Add(new SearchNodeFilter(filter));
+            }
+
+            TreeNodeUtils.IterateNodes(treeData, node => _filters.ForEach(strategy => strategy.Initialize(node)));
+
+            TreeNodeUtils.IterateNodes(treeData, node =>
+            {
+                if (FilterAction(node)) _visibleNodesCount++;
+            });
+        }
+
+        private VisibilityStatus NodeVisibility(TreeNode node) => _filters.Aggregate(VisibilityStatus.None, (current, filter) => current | filter.GetVisibility(node));
+
+        internal bool FilterAction(TreeNode node) => !NodeVisibility(node).HasFlag(VisibilityStatus.NotVisible);
+
+        internal void UpdateAction(TreeNode data, TreeNode display)
+        {
+            var nodeVisibility = NodeVisibility(data);
+
+            if (nodeVisibility.HasFlag(VisibilityStatus.ChildVisible))
+                // this one is not directly visible, gray it out
+                display.ForeColor = Color.LightBlue;
+
+            else if (nodeVisibility.HasFlag(VisibilityStatus.ParentVisible))
+                // this one is not directly visible, gray it out
+                display.ForeColor = Color.DarkGray;
+
+            // this one is visible directly, ensure it is visible (parents are expanded).
+            // it's children are visible as well, but may be not expanded
+            else if (nodeVisibility.HasFlag(VisibilityStatus.Visible))
+            {
+                //expand parents of visible node
+                if (_visibleNodesCount < _limitOfExpandedNodes)
+                {
+                    display.EnsureVisible();
+                }
+                //If too many objects are visible, treeView performance drops dramatically.
+                //In case of many object only entity level is expanded
+                else
+                {
+                    if (data.Tag is Entity)
+                    {
+                        display.EnsureVisible();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Src/SwqlStudio/ObjectExplorer/Filtering/ObsoleteNodeFilter.cs
+++ b/Src/SwqlStudio/ObjectExplorer/Filtering/ObsoleteNodeFilter.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Windows.Forms;
+using SwqlStudio.Metadata;
+
+namespace SwqlStudio.Filtering
+{
+    /// <summary>
+    /// Filtering strategy marks as not visible (VisibilityStatus.None) nodes that does not have visible children nodes.
+    /// All other nodes are marked with no special visibility status (VisibilityStatus.None).
+    /// </summary>
+    internal class ObsoleteNodeFilter : INodeFilterStrategy
+    {
+        private readonly Dictionary<TreeNode, VisibilityStatus> _visibility = new Dictionary<TreeNode, VisibilityStatus>(TreeNodeUtils.ReferenceEqualityComparer.Default);
+
+        public void Initialize(TreeNode node)
+        {
+            InitializeObsoleteVisibility(node);
+        }
+
+        public VisibilityStatus GetVisibility(TreeNode node) => _visibility.ContainsKey(node) ? _visibility[node] : VisibilityStatus.None;
+        
+        private void InitializeObsoleteVisibility(TreeNode node)
+        {
+            if (!_visibility.ContainsKey(node))
+            {
+                _visibility[node] = IsObsolete(node) ? VisibilityStatus.NotVisible : VisibilityStatus.None;
+            }
+        }
+
+        public bool IsObsolete(TreeNode node)
+        {
+            var tag = node?.Tag as IObsoleteMetadata;
+
+            return tag != null && tag.IsObsolete && !HasVisibleChildEntity(node);
+        }
+
+        private bool HasVisibleChildEntity(TreeNode node)
+        {
+            if (node.Nodes.Count == 0)
+            {
+                return false;
+            }
+
+            if (_visibility.ContainsKey(node))
+            {
+                return _visibility[node] == VisibilityStatus.None;
+            }
+
+            foreach (TreeNode child in node.Nodes)
+            {
+                var tag = child?.Tag as Entity;
+                if (tag != null && (!tag.IsObsolete || HasVisibleChildEntity(child)))
+                {
+                    _visibility.Add(node, VisibilityStatus.None);
+                    return true;
+                }
+            }
+
+            _visibility.Add(node, VisibilityStatus.NotVisible);
+            return false;
+        }
+    }
+}

--- a/Src/SwqlStudio/ObjectExplorer/Filtering/SearchNodeFilter.cs
+++ b/Src/SwqlStudio/ObjectExplorer/Filtering/SearchNodeFilter.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Forms;
+
+namespace SwqlStudio.Filtering
+{
+    /// <summary>
+    /// Used in filtering of the nodes in Object explorer. It filters based on provided keyword (filter)
+    /// Everything that match pattern is marked as Visible and all parents of visible nodes are marked as ChildVisible.
+    /// Everything that does not match is considered NotVisible or ParentVisible if there is explicitly visible parent.
+    /// </summary>
+    internal class SearchNodeFilter : INodeFilterStrategy
+    {
+        private readonly string _filter;
+
+        private readonly Dictionary<TreeNode, VisibilityStatus> _visibility = new Dictionary<TreeNode, VisibilityStatus>(TreeNodeUtils.ReferenceEqualityComparer.Default);
+
+        public SearchNodeFilter(string filter)
+        {
+            _filter = filter;
+        }
+
+        public void Initialize(TreeNode node)
+        {
+            if (PassesFilter(node))
+                SetVisible(node);
+        }
+
+        private void SetVisible(TreeNode node)
+        {
+            _visibility[node] = VisibilityStatus.Visible;
+            for (var parent = node.Parent; parent != null; parent = parent.Parent)
+            {
+                _visibility.TryGetValue(parent, out var parentVisibility);
+                if (parentVisibility != VisibilityStatus.Visible)//for deprecated we care for entity only
+                    parentVisibility = VisibilityStatus.ChildVisible;
+
+                _visibility[parent] = parentVisibility;
+            }
+        }
+
+        public VisibilityStatus GetVisibility(TreeNode node)
+        {
+            if (!_visibility.TryGetValue(node, out var rv))
+            {
+                rv = VisibilityStatus.NotVisible;
+                // check if some of the parents is not directly visible (visible, not childvisible)
+                for (var parent = node.Parent; parent != null; parent = parent.Parent)
+                {
+                    if (_visibility.TryGetValue(parent, out var parentVisibility))
+                    {
+                        if (parentVisibility == VisibilityStatus.Visible)
+                            rv = VisibilityStatus.ParentVisible;
+                        else
+                            break;
+                    }
+                }
+            }
+
+            return rv;
+        }
+
+        private bool PassesFilter(TreeNode node)
+        {
+            var nodeText = node.Text.Split('(')[0]; // trim everything after first (, we do not want to use it in search
+
+            if (_filter == null || nodeText.IndexOf(_filter, StringComparison.OrdinalIgnoreCase) >= 0)
+                return true;
+
+            else // behave in 'special' way for dots, and capitals, the same way as resharper does
+                // let's Met.Ent match also METadata...ENTity
+                // also Met.EntNa should match Metadata.EntityName
+            {
+                var filter = SplitTextByCapsAndDot(_filter);
+                var text = SplitTextByCapsAndDot(nodeText);
+
+                int textPivot = 0;
+
+                for (int filterPivot = 0; filterPivot < filter.Count; filterPivot++)
+                {
+                    for (; textPivot <= text.Count; textPivot++)
+                    {
+                        if (textPivot == text.Count)
+                            return false;
+
+                        if (text[textPivot].StartsWith(filter[filterPivot], StringComparison.OrdinalIgnoreCase))
+                            break;
+                    }
+                    textPivot++;
+                }
+
+                return true;
+            }
+        }
+
+        private static List<string> SplitTextByCapsAndDot(string text)
+        {
+            var rv = new List<string>();
+
+            var buf = new StringBuilder();
+
+            void FlushBuffer()
+            {
+                if (buf.Length > 0)
+                    rv.Add(buf.ToString());
+
+                buf.Clear();
+            }
+
+            foreach (var t in text)
+            {
+                if (t == '.')
+                {
+                    FlushBuffer();
+                }
+                else
+                {
+                    if (char.IsUpper(t))
+                        FlushBuffer();
+
+                    buf.Append(t);
+                }
+            }
+
+            FlushBuffer();
+            return rv;
+        }
+    }
+}

--- a/Src/SwqlStudio/ObjectExplorer/Filtering/VisibilityStatus.cs
+++ b/Src/SwqlStudio/ObjectExplorer/Filtering/VisibilityStatus.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace SwqlStudio.Filtering
+{
+    [Flags]
+    internal enum VisibilityStatus
+    {
+        /// <summary>
+        /// Visibility Status is not set for this node
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// This node is not visible
+        /// </summary>
+        NotVisible = 1,
+        /// <summary>
+        /// Some children of this node passed filter
+        /// </summary>
+        ChildVisible = 2,
+        /// <summary>
+        /// This node passed filter
+        /// </summary>
+        Visible = 4,
+        /// <summary>
+        /// This node's parent passed filter
+        /// </summary>
+        ParentVisible = 8
+    }
+}

--- a/Src/SwqlStudio/ObjectExplorer/StringBuilderExtensions.cs
+++ b/Src/SwqlStudio/ObjectExplorer/StringBuilderExtensions.cs
@@ -45,5 +45,13 @@ namespace SwqlStudio
                 builder.Append($"Can Delete: {entity.CanDelete}\r\n");
             }
         }
+
+        public static void AppendObsoleteSection(this StringBuilder builder, IObsoleteMetadata entity)
+        {
+            if (entity != null && entity.IsObsolete)
+            {
+                builder.Append($"Obsolete: {entity.ObsolescenceReason}{Environment.NewLine}");
+            }
+        }
     }
 }

--- a/Src/SwqlStudio/ObjectExplorer/TreeNodeUtils.cs
+++ b/Src/SwqlStudio/ObjectExplorer/TreeNodeUtils.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Windows.Forms;
+using SwqlStudio.Filtering;
+using SwqlStudio.Metadata;
 
 namespace SwqlStudio
 {
@@ -42,9 +44,7 @@ namespace SwqlStudio
                 {
                     newNode = CloneShallow(node);
                 }
-
                 
-
                 target.Add(newNode);
                 bindings.BindNodes(node, newNode);
                 CopyTree(node.Nodes, newNode.Nodes, bindings, filter, updateAction);
@@ -80,71 +80,7 @@ namespace SwqlStudio
             target.ContextMenu = source.ContextMenu;
             target.ContextMenuStrip = source.ContextMenuStrip;
             target.Checked = source.Checked;
-        }
-
-        /// <summary>
-        /// Used in filtering of the nodes.
-        /// 
-        /// Keeps track of visibility of each single one
-        /// </summary>
-        public class NodeVisibility
-        {
-            private readonly Dictionary<TreeNode, VisibilityStatus> _visibility = new Dictionary<TreeNode, VisibilityStatus>(ReferenceEqualityComparer.Default);
-
-
-            public void SetVisible(TreeNode node)
-            {
-                _visibility[node] = VisibilityStatus.Visible;
-                for (var parent = node.Parent; parent != null; parent = parent.Parent)
-                {
-                    _visibility.TryGetValue(parent, out var parentVisibility);
-                    if (parentVisibility != VisibilityStatus.Visible)
-                        parentVisibility = VisibilityStatus.ChildVisible;
-
-                    _visibility[parent] = parentVisibility;
-                }
-            }
-
-            public VisibilityStatus GetVisibility(TreeNode node)
-            {
-                if (!_visibility.TryGetValue(node, out var rv))
-                {
-                    rv = VisibilityStatus.NotVisible;
-                    // check if some of the parents is not directly visible (visible, not childvisible)
-                    for (var parent = node.Parent; parent != null; parent = parent.Parent)
-                    {
-                        if (_visibility.TryGetValue(parent, out var parentVisibility))
-                        {
-                            if (parentVisibility == VisibilityStatus.Visible)
-                                rv = VisibilityStatus.ParentVisible;
-                            else
-                                break;
-                        }
-                    }
-                }
-
-                return rv;
-            }
-
-            public enum VisibilityStatus
-            {
-                /// <summary>
-                /// This node is not visible
-                /// </summary>
-                NotVisible,
-                /// <summary>
-                /// Some children of this node passed filter
-                /// </summary>
-                ChildVisible,
-                /// <summary>
-                /// This node passed filter
-                /// </summary>
-                Visible,
-                /// <summary>
-                /// This node's parent passed filter
-                /// </summary>
-                ParentVisible
-            }
+            target.NodeFont = source.NodeFont;
         }
 
         /// <summary>
@@ -184,7 +120,7 @@ namespace SwqlStudio
                 return rv;
             }
         }
-        private sealed class ReferenceEqualityComparer : IEqualityComparer, IEqualityComparer<object>
+        internal sealed class ReferenceEqualityComparer : IEqualityComparer, IEqualityComparer<object>
         {
             public static ReferenceEqualityComparer Default { get; } = new ReferenceEqualityComparer();
 

--- a/Src/SwqlStudio/Properties/Settings.Designer.cs
+++ b/Src/SwqlStudio/Properties/Settings.Designer.cs
@@ -331,5 +331,17 @@ namespace SwqlStudio.Properties {
                 this["PromptToSaveOnClose"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ShowObsolete {
+            get {
+                return ((bool)(this["ShowObsolete"]));
+            }
+            set {
+                this["ShowObsolete"] = value;
+            }
+        }
     }
 }

--- a/Src/SwqlStudio/Properties/Settings.settings
+++ b/Src/SwqlStudio/Properties/Settings.settings
@@ -98,5 +98,8 @@
     <Setting Name="PromptToSaveOnClose" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="ShowObsolete" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Src/SwqlStudio/QueriesDockPanel.cs
+++ b/Src/SwqlStudio/QueriesDockPanel.cs
@@ -184,6 +184,11 @@ namespace SwqlStudio
             objectExplorer.RefreshAllServers();
         }
 
+        internal void RefreshObjectExplorerFilters()
+        {
+            objectExplorer.RefreshFilters();
+        }
+
         internal void FocusSearch()
         {
             objectExplorer.FocusSearch();

--- a/Src/SwqlStudio/SwqlStudio.csproj
+++ b/Src/SwqlStudio/SwqlStudio.csproj
@@ -212,6 +212,7 @@
     <Compile Include="LogHeaderReaderBehavior.cs" />
     <Compile Include="Metadata\Entity.cs" />
     <Compile Include="Metadata\ITypedMetadata.cs" />
+    <Compile Include="Metadata\IObsoleteMetadata.cs" />
     <Compile Include="Metadata\Property.cs" />
     <Compile Include="Metadata\Verb.cs" />
     <Compile Include="Metadata\VerbArgument.cs" />
@@ -226,6 +227,11 @@
     <Compile Include="ObjectExplorer\DocumentationBuilder.cs" />
     <Compile Include="ObjectExplorer\StringBuilderExtensions.cs" />
     <Compile Include="ObjectExplorer\TreeNodesBuilder.cs" />
+    <Compile Include="ObjectExplorer\Filtering\INodeFilterStrategy.cs" />
+    <Compile Include="ObjectExplorer\Filtering\NodeFilter.cs" />
+    <Compile Include="ObjectExplorer\Filtering\SearchNodeFilter.cs" />
+    <Compile Include="ObjectExplorer\Filtering\ObsoleteNodeFilter.cs" />
+    <Compile Include="ObjectExplorer\Filtering\VisibilityStatus.cs" />
     <Compile Include="ObjectExplorer\TreeNodeUtils.cs" />
     <Compile Include="ProductSpecific\CertificateValidatorWithCache.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/Src/SwqlStudio/app.config
+++ b/Src/SwqlStudio/app.config
@@ -12,13 +12,13 @@
   <userSettings>
     <SwqlStudio.Properties.Settings>
       <setting name="PreviousServers" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="PreviousUsers" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="PreviousServerType" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="UpdateRequired" serializeAs="String">
         <value>True</value>
@@ -30,6 +30,9 @@
         <value>True</value>
       </setting>
       <setting name="PromptToSaveOnClose" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="ShowObsolete" serializeAs="String">
         <value>True</value>
       </setting>
     </SwqlStudio.Properties.Settings>


### PR DESCRIPTION
This pull request covers support for visualization of obsolete API in SWQL Studio:
* Possibility to filter out obsolete nodes from Object Explorer (option in menu)
* Documentation section is extended with obsolescence reason
* ToolTip is extended with obsolescence reason
* Obsolete nodes are styled with strikethrough font

It also covers refactoring of filtering (code is split to smaller classes)