### PR TITLE
Fix parameters copy/paste in SWQL studio

### DIFF
--- a/Src/SwqlStudio/MainForm.Designer.cs
+++ b/Src/SwqlStudio/MainForm.Designer.cs
@@ -72,6 +72,7 @@
             this.enableAutocompleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.discoverQueryParametersMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.promptToSaveOnCloseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showObsoleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutSWQLStudioToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
@@ -93,7 +94,6 @@
             this.newFileToolButton = new System.Windows.Forms.ToolStripButton();
             this.openFileButton = new System.Windows.Forms.ToolStripButton();
             this.saveToolButton = new System.Windows.Forms.ToolStripButton();
-            this.showObsoleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.menu.SuspendLayout();
             this.mainToolbar.SuspendLayout();
@@ -102,12 +102,12 @@
             // toolStripSeparator1
             // 
             toolStripSeparator1.Name = "toolStripSeparator1";
-            toolStripSeparator1.Size = new System.Drawing.Size(216, 6);
+            toolStripSeparator1.Size = new System.Drawing.Size(215, 6);
             // 
             // separatorAboveNotificationListenerActive
             // 
             this.separatorAboveNotificationListenerActive.Name = "separatorAboveNotificationListenerActive";
-            this.separatorAboveNotificationListenerActive.Size = new System.Drawing.Size(216, 6);
+            this.separatorAboveNotificationListenerActive.Size = new System.Drawing.Size(215, 6);
             // 
             // menu
             // 
@@ -148,7 +148,7 @@
             this.menuFileNew.Image = global::SwqlStudio.Properties.Resources.ConnectFilled_16x;
             this.menuFileNew.Name = "menuFileNew";
             this.menuFileNew.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.menuFileNew.Size = new System.Drawing.Size(219, 22);
+            this.menuFileNew.Size = new System.Drawing.Size(218, 22);
             this.menuFileNew.Text = "&New Connection...";
             this.menuFileNew.Click += new System.EventHandler(this.menuFileNew_Click);
             // 
@@ -157,7 +157,7 @@
             this.menuFileTabPage.Image = global::SwqlStudio.Properties.Resources.NewFile_16x;
             this.menuFileTabPage.Name = "menuFileTabPage";
             this.menuFileTabPage.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
-            this.menuFileTabPage.Size = new System.Drawing.Size(219, 22);
+            this.menuFileTabPage.Size = new System.Drawing.Size(218, 22);
             this.menuFileTabPage.Text = "New Query &Tab";
             this.menuFileTabPage.Click += new System.EventHandler(this.menuFileTabPage_Click);
             // 
@@ -166,7 +166,7 @@
             this.menuFileOpen.Image = global::SwqlStudio.Properties.Resources.OpenFolder_16x;
             this.menuFileOpen.Name = "menuFileOpen";
             this.menuFileOpen.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.menuFileOpen.Size = new System.Drawing.Size(219, 22);
+            this.menuFileOpen.Size = new System.Drawing.Size(218, 22);
             this.menuFileOpen.Text = "&Open File...";
             this.menuFileOpen.Click += new System.EventHandler(this.menuFileOpen_Click);
             // 
@@ -175,7 +175,7 @@
             this.menuFileSave.Image = global::SwqlStudio.Properties.Resources.Save_16x;
             this.menuFileSave.Name = "menuFileSave";
             this.menuFileSave.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.menuFileSave.Size = new System.Drawing.Size(219, 22);
+            this.menuFileSave.Size = new System.Drawing.Size(218, 22);
             this.menuFileSave.Text = "&Save";
             this.menuFileSave.Click += new System.EventHandler(this.menuFileSave_Click);
             // 
@@ -183,7 +183,7 @@
             // 
             this.menuFileSaveAs.Name = "menuFileSaveAs";
             this.menuFileSaveAs.ShortcutKeys = System.Windows.Forms.Keys.F12;
-            this.menuFileSaveAs.Size = new System.Drawing.Size(219, 22);
+            this.menuFileSaveAs.Size = new System.Drawing.Size(218, 22);
             this.menuFileSaveAs.Text = "Save &As...";
             this.menuFileSaveAs.Click += new System.EventHandler(this.menuFileSaveAs_Click);
             // 
@@ -192,7 +192,7 @@
             this.menuFileClose.Name = "menuFileClose";
             this.menuFileClose.ShortcutKeyDisplayString = "Ctrl+W, Ctrl+F4";
             this.menuFileClose.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.W)));
-            this.menuFileClose.Size = new System.Drawing.Size(219, 22);
+            this.menuFileClose.Size = new System.Drawing.Size(218, 22);
             this.menuFileClose.Text = "&Close";
             this.menuFileClose.Click += new System.EventHandler(this.menuFileClose_Click);
             // 
@@ -200,7 +200,7 @@
             // 
             this.menuFileClose2.Name = "menuFileClose2";
             this.menuFileClose2.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F4)));
-            this.menuFileClose2.Size = new System.Drawing.Size(219, 22);
+            this.menuFileClose2.Size = new System.Drawing.Size(218, 22);
             this.menuFileClose2.Text = "Close";
             this.menuFileClose2.Visible = false;
             this.menuFileClose2.Click += new System.EventHandler(this.menuFileClose_Click);
@@ -210,14 +210,14 @@
             this.menuNotificationListenerActive.Checked = true;
             this.menuNotificationListenerActive.CheckState = System.Windows.Forms.CheckState.Checked;
             this.menuNotificationListenerActive.Name = "menuNotificationListenerActive";
-            this.menuNotificationListenerActive.Size = new System.Drawing.Size(219, 22);
+            this.menuNotificationListenerActive.Size = new System.Drawing.Size(218, 22);
             this.menuNotificationListenerActive.Text = "Notification Listener Active";
             this.menuNotificationListenerActive.Click += new System.EventHandler(this.menuNotificationListenerActive_Click);
             // 
             // menuFileExit
             // 
             this.menuFileExit.Name = "menuFileExit";
-            this.menuFileExit.Size = new System.Drawing.Size(219, 22);
+            this.menuFileExit.Size = new System.Drawing.Size(218, 22);
             this.menuFileExit.Text = "&Exit";
             this.menuFileExit.Click += new System.EventHandler(this.menuFileExit_Click);
             // 
@@ -226,7 +226,7 @@
             this.searchInTreeHotKeyToolStripMenuItem.Name = "searchInTreeHotKeyToolStripMenuItem";
             this.searchInTreeHotKeyToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+\\";
             this.searchInTreeHotKeyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Oem5)));
-            this.searchInTreeHotKeyToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
+            this.searchInTreeHotKeyToolStripMenuItem.Size = new System.Drawing.Size(218, 22);
             this.searchInTreeHotKeyToolStripMenuItem.Text = "SearchInTreeHotKey";
             this.searchInTreeHotKeyToolStripMenuItem.Visible = false;
             this.searchInTreeHotKeyToolStripMenuItem.Click += new System.EventHandler(this.searchInTreeHotKeyToolStripMenuItem_Click);
@@ -254,7 +254,7 @@
             this.undoToolStripMenuItem.Image = global::SwqlStudio.Properties.Resources.Undo_16x;
             this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
             this.undoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-            this.undoToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.undoToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.undoToolStripMenuItem.Text = "Undo";
             this.undoToolStripMenuItem.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
             // 
@@ -263,20 +263,20 @@
             this.redoToolStripMenuItem.Image = global::SwqlStudio.Properties.Resources.Redo_16x;
             this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
             this.redoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-            this.redoToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.redoToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.redoToolStripMenuItem.Text = "Redo";
             this.redoToolStripMenuItem.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
             // 
             // toolStripSeparator5
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(155, 6);
+            this.toolStripSeparator5.Size = new System.Drawing.Size(177, 6);
             // 
             // findToolStripMenuItem
             // 
             this.findToolStripMenuItem.Name = "findToolStripMenuItem";
             this.findToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.findToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.findToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.findToolStripMenuItem.Text = "&Find";
             this.findToolStripMenuItem.Click += new System.EventHandler(this.findToolStripMenuItem_Click);
             // 
@@ -284,21 +284,21 @@
             // 
             this.replaceToolStripMenuItem.Name = "replaceToolStripMenuItem";
             this.replaceToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.H)));
-            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.replaceToolStripMenuItem.Text = "Replace";
             this.replaceToolStripMenuItem.Click += new System.EventHandler(this.replaceToolStripMenuItem_Click);
             // 
             // toolStripSeparator6
             // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(155, 6);
+            this.toolStripSeparator6.Size = new System.Drawing.Size(177, 6);
             // 
             // menuEditCut
             // 
             this.menuEditCut.Image = ((System.Drawing.Image)(resources.GetObject("menuEditCut.Image")));
             this.menuEditCut.Name = "menuEditCut";
-            this.menuEditCut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this.menuEditCut.Size = new System.Drawing.Size(158, 22);
+            this.menuEditCut.ShortcutKeyDisplayString = "Ctrl+X";
+            this.menuEditCut.Size = new System.Drawing.Size(180, 22);
             this.menuEditCut.Text = "Cu&t";
             this.menuEditCut.Click += new System.EventHandler(this.menuEditCut_Click);
             // 
@@ -306,8 +306,8 @@
             // 
             this.menuEditCopy.Image = global::SwqlStudio.Properties.Resources.ASX_Copy_blue_16x;
             this.menuEditCopy.Name = "menuEditCopy";
-            this.menuEditCopy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.menuEditCopy.Size = new System.Drawing.Size(158, 22);
+            this.menuEditCopy.ShortcutKeyDisplayString = "Ctrl+C";
+            this.menuEditCopy.Size = new System.Drawing.Size(180, 22);
             this.menuEditCopy.Text = "&Copy";
             this.menuEditCopy.Click += new System.EventHandler(this.menuEditCopy_Click);
             // 
@@ -315,8 +315,8 @@
             // 
             this.menuEditPaste.Image = global::SwqlStudio.Properties.Resources.ASX_Paste_blue_16x;
             this.menuEditPaste.Name = "menuEditPaste";
-            this.menuEditPaste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.menuEditPaste.Size = new System.Drawing.Size(158, 22);
+            this.menuEditPaste.ShortcutKeyDisplayString = "Ctrl+V";
+            this.menuEditPaste.Size = new System.Drawing.Size(180, 22);
             this.menuEditPaste.Text = "&Paste";
             this.menuEditPaste.Click += new System.EventHandler(this.menuEditPaste_Click);
             // 
@@ -327,7 +327,7 @@
             this.curlBashToolStripMenuItem,
             this.getSwisDataPowerShellToolStripMenuItem});
             this.copyQueryAsToolStripMenuItem.Name = "copyQueryAsToolStripMenuItem";
-            this.copyQueryAsToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.copyQueryAsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.copyQueryAsToolStripMenuItem.Text = "Copy &Query As";
             // 
             // curlCmdToolStripMenuItem
@@ -471,6 +471,13 @@
             this.promptToSaveOnCloseToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
             this.promptToSaveOnCloseToolStripMenuItem.Text = "Prompt to save on close";
             this.promptToSaveOnCloseToolStripMenuItem.Click += new System.EventHandler(this.promptToSaveOnCloseToolStripMenuItem_Click);
+            // 
+            // showObsoleteToolStripMenuItem
+            // 
+            this.showObsoleteToolStripMenuItem.Name = "showObsoleteToolStripMenuItem";
+            this.showObsoleteToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
+            this.showObsoleteToolStripMenuItem.Text = "Show Obsolete";
+            this.showObsoleteToolStripMenuItem.Click += new System.EventHandler(this.showObsoleteToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
@@ -641,13 +648,6 @@
             this.saveToolButton.Size = new System.Drawing.Size(23, 22);
             this.saveToolButton.ToolTipText = "Save (Ctrl+S)";
             this.saveToolButton.Click += new System.EventHandler(this.menuFileSave_Click);
-            // 
-            // showObsoleteToolStripMenuItem
-            // 
-            this.showObsoleteToolStripMenuItem.Name = "showObsoleteToolStripMenuItem";
-            this.showObsoleteToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
-            this.showObsoleteToolStripMenuItem.Text = "Show Obsolete";
-            this.showObsoleteToolStripMenuItem.Click += new System.EventHandler(this.showObsoleteToolStripMenuItem_Click);
             // 
             // MainForm
             // 

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -306,8 +306,7 @@ namespace SwqlStudio
 
         private void menuQueryExecute_Click(object sender, EventArgs e)
         {
-            if (this.filesDock.ActiveQueryTab != null)
-                this.filesDock.ActiveQueryTab.RunQuery();
+            this.filesDock.ActiveQueryTab?.RunQuery();
         }
 
         private void parametersToolStripMenuItem_Click(object sender, EventArgs e)
@@ -350,8 +349,7 @@ namespace SwqlStudio
 
         private void playbackToolStripMenuItem_Click_1(object sender, EventArgs e)
         {
-            if (this.filesDock.ActiveQueryTab != null)
-                this.filesDock.ActiveQueryTab.RunPlayback();
+            filesDock.ActiveQueryTab?.RunPlayback();
         }
 
         private void aboutSWQLStudioToolStripMenuItem_Click(object sender, EventArgs e)
@@ -492,20 +490,12 @@ namespace SwqlStudio
 
         private void findToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var activeTab = filesDock.ActiveQueryTab;
-            if (activeTab == null)
-                return;
-
-            activeTab.FindDialog();
+            filesDock.ActiveQueryTab?.FindDialog();
         }
 
         private void replaceToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var activeTab = filesDock.ActiveQueryTab;
-            if (activeTab == null)
-                return;
-
-            activeTab.ReplaceDialog();
+            filesDock.ActiveQueryTab?.ReplaceDialog();
         }
 
         private void showObsoleteToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Src/SwqlStudio/QueryParameters.cs
+++ b/Src/SwqlStudio/QueryParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.Linq;
 using SolarWinds.InformationService.Contract2;
 using WeifenLuo.WinFormsUI.Docking;
@@ -8,7 +9,21 @@ namespace SwqlStudio
 {
     public partial class QueryParameters : DockContent
     {
-        public bool AllowSetParameters { get; set; }
+        private bool allowSetParameters;
+
+        public bool AllowSetParameters
+        {
+            get => allowSetParameters;
+            set
+            {
+                allowSetParameters = value;
+                parametersGrid.AllowUserToAddRows = !allowSetParameters;
+                var keyColumn = parametersGrid.Columns[nameof(QueryVariable.Key)];
+                keyColumn.ReadOnly = allowSetParameters;
+                var cellColor = !allowSetParameters ? Color.White : Color.LightGray;
+                keyColumn.DefaultCellStyle.BackColor = cellColor;
+            }
+        }
 
         public QueryParameters()
         {


### PR DESCRIPTION
* Removed general short cut keys from mainForm main menu
* Added switch to customize parameters visual style to respect when the parameter names are auto discovered i.e. readonly