### PR TITLE
Add Powershell examples for NTA

### DIFF
--- a/Samples/PowerShell/NTA.AddCBQoSSources.ps1
+++ b/Samples/PowerShell/NTA.AddCBQoSSources.ps1
@@ -1,0 +1,57 @@
+# This sample scripts demonstrates how to add enabled CBQoS sources 
+# with required Orion node and interfaces. Interfaces are discovered with NPM 
+# discovery feature.
+# You need to be logged as a user with enabled Allow Node Management Rights.
+
+
+# Connect to SWIS
+$hostname = "swis-machine-hostname"                     # Update to match your configuration
+$username = "admin"                                     # Update to match your configuration
+$password = New-Object System.Security.SecureString     # Update to match your configuration
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+
+
+# Default engine ID
+$engineId = 1
+
+# Create Orion Node
+# Update to match your configuration
+$nodeCaption = "my.cbqosnode.corp"
+$newSNMPV2NodeProps = @{
+    IPAddress = "1.1.1.2";
+    EngineID = $engineId;
+    Caption = $nodeCaption;
+    ObjectSubType ='SNMP';
+    Community = "public";
+    SNMPVersion = 2;
+    DNS = "";
+    SysName = "";
+}
+New-SwisObject $swis -EntityType Orion.Nodes -Properties $newSNMPV2NodeProps | Out-Null
+$nodeId = Get-SwisData $swis "SELECT NodeID FROM Orion.Nodes WHERE Caption = '$nodeCaption'"
+Write-Host("New node with ID $nodeId created")
+
+# Discover and create interfaces for Node
+$discovered = Invoke-SwisVerb $swis Orion.NPM.Interfaces DiscoverInterfacesOnNode $nodeId
+if($discovered.Result -ne "Succeed")
+{
+    Write-Error "Interface discovery for node with ID $nodeId failed" -ErrorAction Stop
+}
+Invoke-SwisVerb $swis Orion.NPM.Interfaces AddInterfacesOnNode @($nodeId, $discovered.DiscoveredInterfaces, 'AddDefaultPollers') | Out-Null
+$interfaceIds = Get-SwisData $swis "SELECT InterfaceID FROM Orion.NPM.Interfaces WHERE NodeID = $nodeID"
+Write-Host("Discovered $($interfaceIds.Count) interfaces for new node with ID $nodeId")
+
+# Create enabled CBQoS Sources for every interface on the node
+foreach ($interfaceId in $interfaceIds)
+{
+    $newCBQoSSourceProps = @{
+        NodeID = $nodeId;
+        InterfaceID = $interfaceId;
+        EngineID = $engineId;
+        Enabled = $true;
+    }
+    New-SwisObject $swis -EntityType Orion.Netflow.CBQoSSource -Properties $newCBQoSSourceProps | Out-Null
+}
+$cbqosSourcesIds = Get-SwisData $swis "SELECT CBQoSSourceID FROM Orion.Netflow.CBQoSSource WHERE NodeID = $nodeID"
+Write-Host("$($cbqosSourcesIds.count) enabled CBQoS Sources created")

--- a/Samples/PowerShell/NTA.AddCBQoSSources.ps1
+++ b/Samples/PowerShell/NTA.AddCBQoSSources.ps1
@@ -3,6 +3,7 @@
 # discovery feature.
 # You need to be logged as a user with enabled Allow Node Management Rights.
 
+Import-Module SwisPowerShell
 
 # Connect to SWIS
 $hostname = "swis-machine-hostname"                     # Update to match your configuration
@@ -17,41 +18,39 @@ $engineId = 1
 
 # Create Orion Node
 # Update to match your configuration
-$nodeCaption = "my.cbqosnode.corp"
+$nodeCaption = "example.com"
 $newSNMPV2NodeProps = @{
-    IPAddress = "1.1.1.2";
-    EngineID = $engineId;
-    Caption = $nodeCaption;
-    ObjectSubType ='SNMP';
-    Community = "public";
-    SNMPVersion = 2;
-    DNS = "";
-    SysName = "";
+    IPAddress = "1.1.1.2"
+    EngineID = $engineId
+    Caption = $nodeCaption
+    ObjectSubType ="SNMP"
+    Community = "public"
+    SNMPVersion = 2
+    DNS = ""
+    SysName = ""
 }
-New-SwisObject $swis -EntityType Orion.Nodes -Properties $newSNMPV2NodeProps | Out-Null
-$nodeId = Get-SwisData $swis "SELECT NodeID FROM Orion.Nodes WHERE Caption = '$nodeCaption'"
-Write-Host("New node with ID $nodeId created")
+New-SwisObject -SwisConnection $swis -EntityType Orion.Nodes -Properties $newSNMPV2NodeProps | Out-Null
+$nodeId = Get-SwisData -SwisConnection $swis "SELECT NodeID FROM Orion.Nodes WHERE Caption = @nodeCaption" -Parameters @{nodeCaption = $nodeCaption}
+Write-Host "New node with ID $nodeId created"
 
 # Discover and create interfaces for Node
-$discovered = Invoke-SwisVerb $swis Orion.NPM.Interfaces DiscoverInterfacesOnNode $nodeId
-if($discovered.Result -ne "Succeed")
-{
+$discovered = Invoke-SwisVerb -SwisConnection $swis -EntityName Orion.NPM.Interfaces -Verb DiscoverInterfacesOnNode -Arguments $nodeId
+if($discovered.Result -ne "Succeed") {
     Write-Error "Interface discovery for node with ID $nodeId failed" -ErrorAction Stop
 }
-Invoke-SwisVerb $swis Orion.NPM.Interfaces AddInterfacesOnNode @($nodeId, $discovered.DiscoveredInterfaces, 'AddDefaultPollers') | Out-Null
-$interfaceIds = Get-SwisData $swis "SELECT InterfaceID FROM Orion.NPM.Interfaces WHERE NodeID = $nodeID"
-Write-Host("Discovered $($interfaceIds.Count) interfaces for new node with ID $nodeId")
+Invoke-SwisVerb -SwisConnection $swis -EntityName Orion.NPM.Interfaces -Verb AddInterfacesOnNode -Arguments @($nodeId, $discovered.DiscoveredInterfaces, 'AddDefaultPollers') | Out-Null
+$interfaceIds = Get-SwisData -SwisConnection $swis -Query "SELECT InterfaceID FROM Orion.NPM.Interfaces WHERE NodeID = @nodeID" -Parameters @{nodeID = $nodeId}
+Write-Host "Discovered $($interfaceIds.Count) interfaces for new node with ID $nodeId"
 
 # Create enabled CBQoS Sources for every interface on the node
-foreach ($interfaceId in $interfaceIds)
-{
+foreach ($interfaceId in $interfaceIds) {
     $newCBQoSSourceProps = @{
-        NodeID = $nodeId;
-        InterfaceID = $interfaceId;
-        EngineID = $engineId;
-        Enabled = $true;
+        NodeID = $nodeId
+        InterfaceID = $interfaceId
+        EngineID = $engineId
+        Enabled = $true
     }
-    New-SwisObject $swis -EntityType Orion.Netflow.CBQoSSource -Properties $newCBQoSSourceProps | Out-Null
+    New-SwisObject -SwisConnection $swis -EntityType Orion.Netflow.CBQoSSource -Properties $newCBQoSSourceProps | Out-Null
 }
-$cbqosSourcesIds = Get-SwisData $swis "SELECT CBQoSSourceID FROM Orion.Netflow.CBQoSSource WHERE NodeID = $nodeID"
-Write-Host("$($cbqosSourcesIds.count) enabled CBQoS Sources created")
+$cbqosSourcesIds = Get-SwisData -SwisConnection $swis -Query "SELECT CBQoSSourceID FROM Orion.Netflow.CBQoSSource WHERE NodeID = @nodeID" -Parameters @{nodeID = $nodeId}
+Write-Host "$($cbqosSourcesIds.count) enabled CBQoS Sources created"

--- a/Samples/PowerShell/NTA.AddFlowSources.ps1
+++ b/Samples/PowerShell/NTA.AddFlowSources.ps1
@@ -1,0 +1,48 @@
+# This sample script demonstrates how to add enabled Flow Sources with
+# required Orion node and interfaces. Interfaces are discovered with NPM 
+# discovery feature.
+# You need to be logged as a user with enabled Allow Node Management Rights.
+
+
+# Connect to SWIS
+$hostname = "swis-machine-hostname"                     # Update to match your configuration
+$username = "admin"                                     # Update to match your configuration
+$password = New-Object System.Security.SecureString     # Update to match your configuration
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+
+# Default engine ID
+$engineId = 1
+
+# Create Orion Node
+# Update to match your configuration
+$nodeCaption = "my.netflownode.corp"
+$newSNMPV2NodeProps = @{
+    IPAddress = "1.1.1.1";
+    EngineID = $engineId;
+    Caption = $nodeCaption;
+    ObjectSubType ='SNMP';
+    Community = "public";
+    SNMPVersion = 2;
+    DNS = "";
+    SysName = "";
+}
+New-SwisObject $swis -EntityType Orion.Nodes -Properties $newSNMPV2NodeProps
+$nodeId = Get-SwisData $swis "SELECT NodeID FROM Orion.Nodes WHERE Caption = '$nodeCaption'"
+Write-Host("New node with ID $nodeId created")
+
+# Discover and create interfaces for Node
+$discovered = Invoke-SwisVerb $swis Orion.NPM.Interfaces DiscoverInterfacesOnNode $nodeId
+if($discovered.Result -ne "Succeed")
+{
+    Write-Error "Interface discovery for node with ID $nodeId failed" -ErrorAction Stop
+}
+Invoke-SwisVerb $swis Orion.NPM.Interfaces AddInterfacesOnNode @($nodeId, $discovered.DiscoveredInterfaces, 'AddDefaultPollers') | Out-Null
+$interfaceIds = Get-SwisData $swis "SELECT InterfaceID FROM Orion.NPM.Interfaces WHERE NodeID = $nodeID"
+$interfaceIds = $interfaceIds |% {[int]$_}
+Write-Host("Discovered $($interfaceIds.Count) interfaces for new node with ID $nodeId")
+
+# Enable Flow Collection on every interface of the router - Create Netflow Sources
+Invoke-SwisVerb $swis Orion.Netflow.Source EnableFlowSources @(,$interfaceIds) | Out-Null
+$flowSourcesIds = Get-SwisData $swis "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = $nodeID"
+Write-Host("$($flowSourcesIds.Count) Netflow Sources created")

--- a/Samples/PowerShell/NTA.AddFlowSources.ps1
+++ b/Samples/PowerShell/NTA.AddFlowSources.ps1
@@ -3,6 +3,7 @@
 # discovery feature.
 # You need to be logged as a user with enabled Allow Node Management Rights.
 
+Import-Module SwisPowerShell
 
 # Connect to SWIS
 $hostname = "swis-machine-hostname"                     # Update to match your configuration
@@ -16,33 +17,32 @@ $engineId = 1
 
 # Create Orion Node
 # Update to match your configuration
-$nodeCaption = "my.netflownode.corp"
+$nodeCaption = "example.com"
 $newSNMPV2NodeProps = @{
-    IPAddress = "1.1.1.1";
-    EngineID = $engineId;
-    Caption = $nodeCaption;
-    ObjectSubType ='SNMP';
-    Community = "public";
-    SNMPVersion = 2;
-    DNS = "";
-    SysName = "";
+    IPAddress = "1.1.1.1"
+    EngineID = $engineId
+    Caption = $nodeCaption
+    ObjectSubType ="SNMP"
+    Community = "public"
+    SNMPVersion = 2
+    DNS = ""
+    SysName = ""
 }
-New-SwisObject $swis -EntityType Orion.Nodes -Properties $newSNMPV2NodeProps
-$nodeId = Get-SwisData $swis "SELECT NodeID FROM Orion.Nodes WHERE Caption = '$nodeCaption'"
-Write-Host("New node with ID $nodeId created")
+New-SwisObject -SwisConnection $swis -EntityType Orion.Nodes -Properties $newSNMPV2NodeProps
+$nodeId = Get-SwisData -SwisConnection $swis -Query "SELECT NodeID FROM Orion.Nodes WHERE Caption = @nodeCaption" -Parameters @{nodeCaption = $nodeCaption}
+Write-Host "New node with ID $nodeId created"
 
 # Discover and create interfaces for Node
-$discovered = Invoke-SwisVerb $swis Orion.NPM.Interfaces DiscoverInterfacesOnNode $nodeId
-if($discovered.Result -ne "Succeed")
-{
+$discovered = Invoke-SwisVerb -SwisConnection $swis -EntityName Orion.NPM.Interfaces -Verb DiscoverInterfacesOnNode -Arguments $nodeId
+if($discovered.Result -ne "Succeed") {
     Write-Error "Interface discovery for node with ID $nodeId failed" -ErrorAction Stop
 }
-Invoke-SwisVerb $swis Orion.NPM.Interfaces AddInterfacesOnNode @($nodeId, $discovered.DiscoveredInterfaces, 'AddDefaultPollers') | Out-Null
-$interfaceIds = Get-SwisData $swis "SELECT InterfaceID FROM Orion.NPM.Interfaces WHERE NodeID = $nodeID"
-$interfaceIds = $interfaceIds |% {[int]$_}
-Write-Host("Discovered $($interfaceIds.Count) interfaces for new node with ID $nodeId")
+Invoke-SwisVerb -SwisConnection $swis -EntityName Orion.NPM.Interfaces -Verb AddInterfacesOnNode -Arguments @($nodeId, $discovered.DiscoveredInterfaces, 'AddDefaultPollers') | Out-Null
+$interfaceIds = Get-SwisData -SwisConnection $swis -Query "SELECT InterfaceID FROM Orion.NPM.Interfaces WHERE NodeID = @nodeID" -Parameters @{nodeID = $nodeId}
+$interfaceIds = $interfaceIds | ForEach-Object {[int]$_}
+Write-Host "Discovered $($interfaceIds.Count) interfaces for new node with ID $nodeId" 
 
 # Enable Flow Collection on every interface of the router - Create Netflow Sources
-Invoke-SwisVerb $swis Orion.Netflow.Source EnableFlowSources @(,$interfaceIds) | Out-Null
-$flowSourcesIds = Get-SwisData $swis "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = $nodeID"
+Invoke-SwisVerb -SwisConnection $swis -EntityName Orion.Netflow.Source -Verb EnableFlowSources -Arguments @(,$interfaceIds) | Out-Null
+$flowSourcesIds = Get-SwisData -SwisConnection $swis -Query "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = @nodeID" -Parameters @{nodeID = $nodeId}
 Write-Host("$($flowSourcesIds.Count) Netflow Sources created")

--- a/Samples/PowerShell/NTA.ChangeSettings.ps1
+++ b/Samples/PowerShell/NTA.ChangeSettings.ps1
@@ -1,0 +1,25 @@
+# This sample script demonstrates how to change Netflow related Orion Settings
+# for example to enable/disable CBQoS polling.
+# You need to be logged as a user with admin rights.
+
+
+# Connect to SWIS
+$hostname = "swis-machine-hostname"                     # Update to match your configuration
+$username = "admin"                                     # Update to match your configuration
+$password = New-Object System.Security.SecureString     # Update to match your configuration
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+
+# List available Orion Settings
+# Uncomment if you want to get  all available Orion Settings
+# Get-SwisData $swis "SELECT SettingID, Name, Description, Units, Minimum, Maximum, CurrentValue, DefaultValue, Hint FROM Orion.Settings"
+
+# Enable/Disable CBQoS polling
+$settingId = 'CBQoS_Enabled'
+$settingUri = Get-SwisData $swis "SELECT Uri FROM Orion.Settings WHERE SettingID = '$settingId'"
+$props = @{
+    CurrentValue = 0;   # Change this value to 1 to enable setting
+}
+Set-SwisObject $swis -Uri $settingUri -Properties $props | Out-Null
+$settingUri = Get-SwisData $swis "SELECT CurrentValue FROM Orion.Settings WHERE SettingID = '$settingId'"
+Write-Host("Setting $settingId has value $currentValue")

--- a/Samples/PowerShell/NTA.ChangeSettings.ps1
+++ b/Samples/PowerShell/NTA.ChangeSettings.ps1
@@ -2,6 +2,7 @@
 # for example to enable/disable CBQoS polling.
 # You need to be logged as a user with admin rights.
 
+Import-Module SwisPowerShell
 
 # Connect to SWIS
 $hostname = "swis-machine-hostname"                     # Update to match your configuration
@@ -12,14 +13,14 @@ $swis = Connect-Swis -host $hostname -cred $cred
 
 # List available Orion Settings
 # Uncomment if you want to get  all available Orion Settings
-# Get-SwisData $swis "SELECT SettingID, Name, Description, Units, Minimum, Maximum, CurrentValue, DefaultValue, Hint FROM Orion.Settings"
+# Get-SwisData -SwisConnection $swis -Query "SELECT SettingID, Name, Description, Units, Minimum, Maximum, CurrentValue, DefaultValue, Hint FROM Orion.Settings"
 
 # Enable/Disable CBQoS polling
 $settingId = 'CBQoS_Enabled'
-$settingUri = Get-SwisData $swis "SELECT Uri FROM Orion.Settings WHERE SettingID = '$settingId'"
+$settingUri = Get-SwisData -SwisConnection $swis -Query "SELECT Uri FROM Orion.Settings WHERE SettingID = @settingId" -Parameters @{settingId = $settingId}
 $props = @{
     CurrentValue = 0;   # Change this value to 1 to enable setting
 }
-Set-SwisObject $swis -Uri $settingUri -Properties $props | Out-Null
-$settingUri = Get-SwisData $swis "SELECT CurrentValue FROM Orion.Settings WHERE SettingID = '$settingId'"
-Write-Host("Setting $settingId has value $currentValue")
+Set-SwisObject -SwisConnection $swis -Uri $settingUri -Properties $props | Out-Null
+$settingUri = Get-SwisData -SwisConnection $swis -Query "SELECT CurrentValue FROM Orion.Settings WHERE SettingID = @settingId" -Parameters @{settingId = $settingId}
+Write-Host "Setting $settingId has value $currentValue"

--- a/Samples/PowerShell/NTA.DownloadRouterConfigFromNCM.ps1
+++ b/Samples/PowerShell/NTA.DownloadRouterConfigFromNCM.ps1
@@ -1,0 +1,54 @@
+# This sample script demonstrates how to download configuration for Router
+# from NCM. You can use it to verify Netflow related configuration on the Router.
+
+
+# Connect to SWIS
+$hostname = "swis-machine-hostname"                     # Update to match your configuration
+$username = "admin"                                     # Update to match your configuration
+$password = New-Object System.Security.SecureString     # Update to match your configuration
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+
+# Get Orion Node, Interface, Netflow Source information and Router identifiers for concrete Netflow Source
+# You can use these alternative conditions
+# If you know NetflowSourceID: WHERE S.NetflowSourceID = $netflowSourceId
+# If you know NodeName: WHERE N.NodeName = '$nodeName'
+# If you know InterfaceName: WHERE I.InterfaceName = '$interfaceName'
+$nodeName = "my.netflownode.corp"       # Update to match your configuration
+$interfaceName = "GigabitEthernet0/1"   # Update to match your configuration
+
+$query= "
+SELECT s.NetflowSourceID, s.NodeID, s.InterfaceID, s.Enabled, s.LastTimeFlow, s.LastTime, s.EngineID, 
+    s.Node.NodeName,
+    s.Interface.Name as InterfaceName, s.Interface.Index as RouterIndex
+FROM Orion.Netflow.Source s
+WHERE s.Node.NodeName = '$nodeName' AND s.Interface.InterfaceName = '$interfaceName'
+"
+$netflowSourceInfo = Get-SwisData $swis $query
+if(!$netflowSourceInfo) 
+{
+    Write-Error "Netflow Source information not found" -ErrorAction Stop
+}
+
+# Works only if NCM is installed
+# Retrieve latest NCM configuration file for concrete node identified by Orion Node ID
+# You can use it to check node configuration - for example verify Netflow configuration
+$orionNodeId = $netflowSourceInfo.NodeID
+$query = "
+SELECT TOP 1 C.NodeID AS NcmNodeId, C.NodeProperties.CoreNodeId, C.DownloadTime, C.ConfigType, C.Config
+FROM NCM.ConfigArchive C
+WHERE C.NodeProperties.CoreNodeID = $orionNodeId
+ORDER BY C.DownloadTime DESC
+"
+
+$lastConfigData = Get-SwisData $swis $query
+if(!$lastConfigData)
+{
+    Write-Error "Node with ID $orionNodeId is not configured in NCM or no configuration for this node has been loaded yet" -ErrorAction Stop
+}
+Write-Host("Configuration for node with name $nodeName, Orion ID $orionNodeId, NCM Node ID = $($lastConfigData.NcmNodeId)")
+# Uncomment if you want to write configuration to console
+# Write-Host($lastConfigData.Config)
+
+# You can analyze configuration manually or write some parser. To identify data related to concrete Netflow Source 
+# you can use retrieved information in $netflowSourceInfo object like: $netflowSourceInfo.InterfaceName, $netflowSourceInfo.RouterIndex

--- a/Samples/PowerShell/NTA.DownloadRouterConfigFromNCM.ps1
+++ b/Samples/PowerShell/NTA.DownloadRouterConfigFromNCM.ps1
@@ -1,6 +1,7 @@
 # This sample script demonstrates how to download configuration for Router
 # from NCM. You can use it to verify Netflow related configuration on the Router.
 
+Import-Module SwisPowerShell
 
 # Connect to SWIS
 $hostname = "swis-machine-hostname"                     # Update to match your configuration
@@ -12,9 +13,9 @@ $swis = Connect-Swis -host $hostname -cred $cred
 # Get Orion Node, Interface, Netflow Source information and Router identifiers for concrete Netflow Source
 # You can use these alternative conditions
 # If you know NetflowSourceID: WHERE S.NetflowSourceID = $netflowSourceId
-# If you know NodeName: WHERE N.NodeName = '$nodeName'
-# If you know InterfaceName: WHERE I.InterfaceName = '$interfaceName'
-$nodeName = "my.netflownode.corp"       # Update to match your configuration
+# If you know NodeName: WHERE s.Node.NodeName = '$nodeName'
+# If you know InterfaceName: WHERE s.Interface.InterfaceName = '$interfaceName'
+$nodeName = "example.com"               # Update to match your configuration
 $interfaceName = "GigabitEthernet0/1"   # Update to match your configuration
 
 $query= "
@@ -22,11 +23,15 @@ SELECT s.NetflowSourceID, s.NodeID, s.InterfaceID, s.Enabled, s.LastTimeFlow, s.
     s.Node.NodeName,
     s.Interface.Name as InterfaceName, s.Interface.Index as RouterIndex
 FROM Orion.Netflow.Source s
-WHERE s.Node.NodeName = '$nodeName' AND s.Interface.InterfaceName = '$interfaceName'
+WHERE s.Node.NodeName = @nodeName AND s.Interface.InterfaceName = @interfaceName
 "
-$netflowSourceInfo = Get-SwisData $swis $query
-if(!$netflowSourceInfo) 
-{
+$params = @{
+    nodeName = $nodeName
+    interfaceName = $interfaceName
+}
+
+$netflowSourceInfo = Get-SwisData -SwisConnection $swis -Query $query -Parameters $params
+if(!$netflowSourceInfo) {
     Write-Error "Netflow Source information not found" -ErrorAction Stop
 }
 
@@ -37,18 +42,20 @@ $orionNodeId = $netflowSourceInfo.NodeID
 $query = "
 SELECT TOP 1 C.NodeID AS NcmNodeId, C.NodeProperties.CoreNodeId, C.DownloadTime, C.ConfigType, C.Config
 FROM NCM.ConfigArchive C
-WHERE C.NodeProperties.CoreNodeID = $orionNodeId
+WHERE C.NodeProperties.CoreNodeID = @orionNodeId
 ORDER BY C.DownloadTime DESC
 "
+$params = @{
+    orionNodeId = $orionNodeId
+}
 
-$lastConfigData = Get-SwisData $swis $query
-if(!$lastConfigData)
-{
+$lastConfigData = Get-SwisData -SwisConnection $swis -Query $query -Parameters $params
+if(!$lastConfigData) {
     Write-Error "Node with ID $orionNodeId is not configured in NCM or no configuration for this node has been loaded yet" -ErrorAction Stop
 }
-Write-Host("Configuration for node with name $nodeName, Orion ID $orionNodeId, NCM Node ID = $($lastConfigData.NcmNodeId)")
+Write-Host "Configuration for node with name $nodeName, Orion ID $orionNodeId, NCM Node ID = $($lastConfigData.NcmNodeId)"
 # Uncomment if you want to write configuration to console
-# Write-Host($lastConfigData.Config)
+# Write-Host $lastConfigData.Config
 
 # You can analyze configuration manually or write some parser. To identify data related to concrete Netflow Source 
 # you can use retrieved information in $netflowSourceInfo object like: $netflowSourceInfo.InterfaceName, $netflowSourceInfo.RouterIndex

--- a/Samples/PowerShell/NTA.EnableDisableAlert.ps1
+++ b/Samples/PowerShell/NTA.EnableDisableAlert.ps1
@@ -1,0 +1,26 @@
+# This sample script demonstrates how to enable/disable NTA alert identified
+# by its name.
+# You need to be logged as a user with Allow Alert Management rights.
+
+
+# Connect to SWIS
+$hostname = "swis-machine-hostname"                     # Update to match your configuration
+$username = "admin"                                     # Update to match your configuration
+$password = New-Object System.Security.SecureString     # Update to match your configuration
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+
+$alertName = "NTA Alert on machine-hostname"
+$alertUri = Get-SwisData $swis "Select Uri FROM Orion.AlertConfigurations WHERE Name = '$alertName'"
+
+# Disable alert
+$enabledProps = @{
+    Enabled = $false;
+}
+Set-SwisObject $swis -Uri $alertUri -Properties $enabledProps | Out-Null
+
+# Enable alert
+$enabledProps = @{
+    Enabled = $true;
+}
+Set-SwisObject $swis -Uri $alertUri -Properties $enabledProps | Out-Null

--- a/Samples/PowerShell/NTA.EnableDisableAlert.ps1
+++ b/Samples/PowerShell/NTA.EnableDisableAlert.ps1
@@ -2,6 +2,7 @@
 # by its name.
 # You need to be logged as a user with Allow Alert Management rights.
 
+Import-Module SwisPowerShell
 
 # Connect to SWIS
 $hostname = "swis-machine-hostname"                     # Update to match your configuration
@@ -11,16 +12,16 @@ $cred = New-Object -typename System.Management.Automation.PSCredential -argument
 $swis = Connect-Swis -host $hostname -cred $cred
 
 $alertName = "NTA Alert on machine-hostname"
-$alertUri = Get-SwisData $swis "Select Uri FROM Orion.AlertConfigurations WHERE Name = '$alertName'"
+$alertUri = Get-SwisData -SwisConnection $swis -Query "Select Uri FROM Orion.AlertConfigurations WHERE Name = @alertName" -Parameters @{alertName = $alertName}
 
 # Disable alert
 $enabledProps = @{
     Enabled = $false;
 }
-Set-SwisObject $swis -Uri $alertUri -Properties $enabledProps | Out-Null
+Set-SwisObject -SwisConnection $swis -Uri $alertUri -Properties $enabledProps | Out-Null
 
 # Enable alert
 $enabledProps = @{
     Enabled = $true;
 }
-Set-SwisObject $swis -Uri $alertUri -Properties $enabledProps | Out-Null
+Set-SwisObject -SwisConnection $swis -Uri $alertUri -Properties $enabledProps | Out-Null

--- a/Samples/PowerShell/NTA.EnableDisableCBQoSSources.ps1
+++ b/Samples/PowerShell/NTA.EnableDisableCBQoSSources.ps1
@@ -1,0 +1,37 @@
+# This sample script demonstrates how to enable/disable CBQoS source
+# identified by its Caption
+# You need to be logged as a user with enabled Allow Node Management Rights.
+
+
+# Connect to SWIS
+$hostname = "swis-machine-hostname"                     # Update to match your configuration
+$username = "admin"                                     # Update to match your configuration
+$password = New-Object System.Security.SecureString     # Update to match your configuration
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+
+# Disable CBQoS Sources
+$nodeCaption = "My testing router"
+$nodeId = Get-SwisData $swis "SELECT NodeID FROM Orion.Nodes WHERE Caption = '$nodeCaption'"
+$cbqosSourcesUris = Get-SwisData $swis "SELECT Uri FROM Orion.Netflow.CBQoSSource WHERE NodeID = $nodeID"
+
+$disableProps = @{
+    Enabled = $false;
+}
+foreach ($cbqosSourcesUri in $cbqosSourcesUris)
+{
+    Set-SwisObject $swis -Uri $cbqosSourcesUri -Properties $disableProps | Out-Null
+}
+$disableCbqosSourcesIds = Get-SwisData $swis "SELECT CBQoSSourceID FROM Orion.Netflow.CBQoSSource WHERE NodeID = $nodeID and Enabled = false"
+Write-Host("Disabled $($disableCbqosSourcesIds.Count) CBQoS Sources for Node with ID $nodeId. Total interface count $($cbqosSourcesUris.Count).")
+
+# Enable CBQoS Sources
+$enabledProps = @{
+    Enabled = $true;
+}
+foreach ($cbqosSourcesUri in $cbqosSourcesUris)
+{
+    Set-SwisObject $swis -Uri $cbqosSourcesUri -Properties $enabledProps | Out-Null
+}
+$enabledCbqosSourcesIds = Get-SwisData $swis "SELECT CBQoSSourceID FROM Orion.Netflow.CBQoSSource WHERE NodeID = $nodeID and Enabled = true"
+Write-Host("Enabled $($enabledCbqosSourcesIds.Count) CBQoS sources for Node with ID $nodeId. Total interface count $($cbqosSourcesUris.Count).")

--- a/Samples/PowerShell/NTA.EnableDisableFlowSources.ps1
+++ b/Samples/PowerShell/NTA.EnableDisableFlowSources.ps1
@@ -1,0 +1,26 @@
+# This sample script demonstrates how to enable/disable Flow Source
+# identified by its Caption.
+# You need to be logged as a user with enabled Allow Node Management Rights.
+
+
+# Connect to SWIS
+$hostname = "swis-machine-hostname"                     # Update to match your configuration
+$username = "admin"                                     # Update to match your configuration
+$password = New-Object System.Security.SecureString     # Update to match your configuration
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+
+
+# Disable Flow Sources
+$nodeCaption = "My test router"
+$nodeId = Get-SwisData $swis "SELECT NodeID FROM Orion.Nodes WHERE Caption = '$nodeCaption'"
+$flowSourcesIds = Get-SwisData $swis "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = $nodeID"
+$flowSourcesIds = $flowSourcesIds |% {[int]$_}
+Invoke-SwisVerb $swis Orion.Netflow.Source DisableFlowSources @(,$flowSourcesIds) | Out-Null
+$disableflowSourcesIds = Get-SwisData $swis "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = $nodeID and Enabled = false"
+Write-Host("Disabled $($disableflowSourcesIds.Count) Flow Sources for node with ID $nodeId. Total interface count $($flowSourcesIds.Count)")
+
+# Enable Flow Sources
+Invoke-SwisVerb $swis Orion.Netflow.Source EnableFlowSources @(,$flowSourcesIds) | Out-Null
+$enabledflowSourcesIds = Get-SwisData $swis "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = $nodeID and Enabled = true"
+Write-Host("Enabled $($enabledflowSourcesIds.Count) Flow Sources for Node with ID $nodeId. Total interface count $($flowSourcesIds.Count)")

--- a/Samples/PowerShell/NTA.EnableDisableFlowSources.ps1
+++ b/Samples/PowerShell/NTA.EnableDisableFlowSources.ps1
@@ -2,6 +2,7 @@
 # identified by its Caption.
 # You need to be logged as a user with enabled Allow Node Management Rights.
 
+Import-Module SwisPowerShell
 
 # Connect to SWIS
 $hostname = "swis-machine-hostname"                     # Update to match your configuration
@@ -13,14 +14,14 @@ $swis = Connect-Swis -host $hostname -cred $cred
 
 # Disable Flow Sources
 $nodeCaption = "My test router"
-$nodeId = Get-SwisData $swis "SELECT NodeID FROM Orion.Nodes WHERE Caption = '$nodeCaption'"
-$flowSourcesIds = Get-SwisData $swis "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = $nodeID"
-$flowSourcesIds = $flowSourcesIds |% {[int]$_}
-Invoke-SwisVerb $swis Orion.Netflow.Source DisableFlowSources @(,$flowSourcesIds) | Out-Null
-$disableflowSourcesIds = Get-SwisData $swis "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = $nodeID and Enabled = false"
-Write-Host("Disabled $($disableflowSourcesIds.Count) Flow Sources for node with ID $nodeId. Total interface count $($flowSourcesIds.Count)")
+$nodeId = Get-SwisData -SwisConnection $swis -Query "SELECT NodeID FROM Orion.Nodes WHERE Caption = @nodeCaption" -Parameters @{nodeCaption = $nodeCaption}
+$flowSourcesIds = Get-SwisData -SwisConnection $swis -Query "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = @nodeID" -Parameters @{nodeID = $nodeId}
+$flowSourcesIds = $flowSourcesIds | ForEach-Object {[int]$_}
+Invoke-SwisVerb -SwisConnection $swis -Query Orion.Netflow.Source DisableFlowSources @(,$flowSourcesIds) | Out-Null
+$disableflowSourcesIds = Get-SwisData -SwisConnection $swis -Query "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = @nodeID and Enabled = false" -Parameters @{nodeID = $nodeId}
+Write-Host "Disabled $($disableflowSourcesIds.Count) Flow Sources for node with ID $nodeId. Total interface count $($flowSourcesIds.Count)"
 
 # Enable Flow Sources
-Invoke-SwisVerb $swis Orion.Netflow.Source EnableFlowSources @(,$flowSourcesIds) | Out-Null
-$enabledflowSourcesIds = Get-SwisData $swis "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = $nodeID and Enabled = true"
-Write-Host("Enabled $($enabledflowSourcesIds.Count) Flow Sources for Node with ID $nodeId. Total interface count $($flowSourcesIds.Count)")
+Invoke-SwisVerb -SwisConnection $swis -EntityName Orion.Netflow.Source -Verb EnableFlowSources -Arguments @(,$flowSourcesIds) | Out-Null
+$enabledflowSourcesIds = Get-SwisData -SwisConnection $swis -Query "SELECT NetflowSourceID FROM Orion.Netflow.Source WHERE NodeID = @nodeID and Enabled = true" -Parameters @{nodeID = $nodeId}
+Write-Host "Enabled $($enabledflowSourcesIds.Count) Flow Sources for Node with ID $nodeId. Total interface count $($flowSourcesIds.Count)"


### PR DESCRIPTION
* Add Powershell examples for NTA - add and enable/disable Flow and CBQoS source with orion node and interfaces, activate/deactivate NTA alert, change NTA related Orion settings, download latest NCM config.

* Split NTA examples into separate files

* Using navigation properties instead of inner joins