### PR TITLE
Filter Operator Samples

### DIFF
--- a/Samples/PowerShell/Groups.ps1
+++ b/Samples/PowerShell/Groups.ps1
@@ -29,22 +29,22 @@ $swis = Connect-Swis -host $hostname -cred $cred
 <# Filter samples w/ all operators:
 
 IP_Address is 192.168.10.10
-filter:\Orion.Nodes[IP_Address='192.168.10.10')]
+filter:/Orion.Nodes[IP_Address='192.168.10.10')]
 
 IP_Address is not 192.168.10.10
-filter:\Orion.Nodes[IP_Address!='192.168.10.10']
+filter:/Orion.Nodes[IP_Address!='192.168.10.10']
 
 IP_Address starts with 192.168.10.
 filter:/Orion.Nodes[StartsWith(IP_Address,'192.168.10.')]
 
 IP_Address ends with .10.%
-filter:\Orion.Nodes[EndsWith(IP_Address,'10.%')]
+filter:/Orion.Nodes[EndsWith(IP_Address,'10.%')]
 
 IP_Address contains .10.
-filter:\Orion.Nodes[Contains(IP_Address,'.10.')]
+filter:/Orion.Nodes[Contains(IP_Address,'.10.')]
 
 IP_Address matches 192.168.*
-filter:\Orion.Nodes[Pattern(IP_Address,'192.168.%')]
+filter:/Orion.Nodes[Pattern(IP_Address,'192.168.%')]
 
 #>
 

--- a/Samples/PowerShell/Groups.ps1
+++ b/Samples/PowerShell/Groups.ps1
@@ -26,6 +26,28 @@ $swis = Connect-Swis -host $hostname -cred $cred
 # Creating a new group with initial Cisco and Windows devices.
 #
 
+<# Filter samples w/ all operators:
+
+IP_Address is 192.168.10.10
+filter:\Orion.Nodes[IP_Address='192.168.10.10')]
+
+IP_Address is not 192.168.10.10
+filter:\Orion.Nodes[IP_Address!='192.168.10.10']
+
+IP_Address starts with 192.168.10.
+filter:/Orion.Nodes[StartsWith(IP_Address,'192.168.10.')]
+
+IP_Address ends with .10.%
+filter:\Orion.Nodes[EndsWith(IP_Address,'10.%')]
+
+IP_Address contains .10.
+filter:\Orion.Nodes[Contains(IP_Address,'.10.')]
+
+IP_Address matches 192.168.*
+filter:\Orion.Nodes[Pattern(IP_Address,'192.168.%')]
+
+#>
+
 $members = @(
     @{ Name = "Cisco Devices"; Definition = "filter:/Orion.Nodes[Vendor='Cisco']" },
     @{ Name = "Windows Devices"; Definition = "filter:/Orion.Nodes[Vendor='Windows']" }

--- a/Samples/PowerShell/Groups.ps1
+++ b/Samples/PowerShell/Groups.ps1
@@ -38,7 +38,7 @@ IP_Address starts with 192.168.10.
 filter:/Orion.Nodes[StartsWith(IP_Address,'192.168.10.')]
 
 IP_Address ends with .10.%
-filter:/Orion.Nodes[EndsWith(IP_Address,'10.%')]
+filter:/Orion.Nodes[EndsWith(IP_Address,'.10.%')]
 
 IP_Address contains .10.
 filter:/Orion.Nodes[Contains(IP_Address,'.10.')]


### PR DESCRIPTION
Just proposing that we add a commented section with samples of how to use more than just the 'is' or '=' operator in the Samples > PowerShell > Groups.ps1. This is also on [thwack](https://thwack.solarwinds.com/thread/130737).