### PR TITLE
Target .NET Framework 4.8 and a little .NET Standard support

### DIFF
--- a/Src/Contract/SolarWinds.InformationService.Contract.csproj
+++ b/Src/Contract/SolarWinds.InformationService.Contract.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <RootNamespace>SolarWinds.InformationService.Contract2</RootNamespace>
     <AssemblyName>SolarWinds.SDK.Swis.Contract</AssemblyName>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/Src/Contract/Tests/InformationService.Contract.Tests/InformationService.Contract.Tests.csproj
+++ b/Src/Contract/Tests/InformationService.Contract.Tests/InformationService.Contract.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <RootNamespace>SolarWinds.InformationService.Contract2</RootNamespace>
     <AssemblyName>InformationService.Contract.Tests</AssemblyName>
   </PropertyGroup>

--- a/Src/Logging/Log.cs
+++ b/Src/Logging/Log.cs
@@ -8,6 +8,7 @@ using System.Xml;
 using log4net.Util;
 using System.Globalization;
 using System.Linq;
+using System.Configuration;
 
 namespace SolarWinds.Logging
 {
@@ -124,7 +125,8 @@ namespace SolarWinds.Logging
 
             // Configure log4net within application configuration file
             // For web apps, this will work if the config info is in web.config:
-            Configure(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile);
+            var configuration = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            Configure(configuration.FilePath);
         }
 
         static void CurrentDomain_AssemblyLoad(object sender, AssemblyLoadEventArgs args)
@@ -262,7 +264,8 @@ namespace SolarWinds.Logging
                     yield return Path.Combine(Path.GetDirectoryName(entryAssembly.Location), Path.GetFileName(fileName));
             }
 
-            yield return AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+            var configuration = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            yield return configuration.FilePath;
         }
 
         #region Log Forwarding Members

--- a/Src/Logging/SolarWinds.Logging.csproj
+++ b/Src/Logging/SolarWinds.Logging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Authors>SolarWinds</Authors>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
@@ -12,7 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
+    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Logging/SolarWinds.Logging.csproj
+++ b/Src/Logging/SolarWinds.Logging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <Authors>SolarWinds</Authors>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/Src/SwisPowerShell/SwisPowerShell.csproj
+++ b/Src/SwisPowerShell/SwisPowerShell.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>

--- a/Src/SwqlStudio/SwqlStudio.csproj
+++ b/Src/SwqlStudio/SwqlStudio.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>WinExe</OutputType>
     <OutputPath>..\..\bin\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Test/SwisPowerShell.Tests/SwisPowerShell.Tests.csproj
+++ b/Test/SwisPowerShell.Tests/SwisPowerShell.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated all projects to target net48, and updated **SolarWinds.Logging** to dual-target net48 and netstandard2.0.  This required updating **log4net** from 2.0.3 to 2.0.10 and introducing a dependency on **System.Configuration.ConfigurationManager** for easy access to the configuration file path.  Made minor updates to the `Log` class to leverage this library.

This change is intended to make it easier to tackle #239.  It will probably require some downstream changes to the installer, and it would raise the required version of .NET Framework to 4.8.