### PR TITLE
Startup / shutdown scripts for Windows

### DIFF
--- a/Samples/PowerShell/WindowsStartupShutdownScripts/AddNodeToOrionOnStartup.ps1
+++ b/Samples/PowerShell/WindowsStartupShutdownScripts/AddNodeToOrionOnStartup.ps1
@@ -1,0 +1,110 @@
+# This sample script demonstrates how to add a new node using CRUD operations.
+#
+# Please update the hostname and credential setup to match your configuration, and
+# information about the node you would like to add for monitoring.
+
+#Install Nuget and SwisPowerShell modules
+#On some environments we encountered an issue with executing below command, in that case try adding this command before: [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12, it will set tls version to 1.2
+Find-PackageProvider -Name "Nuget"  -RequiredVersion "2.8.5.208" | Install-PackageProvider -Force
+
+#The below line can be deleted if SwisPowerShell is already installed
+Install-Module -Name SwisPowerShell -Force 
+Import-Module SwisPowerShell -Force
+
+#Decide if you want monitor machine by Agent
+$deployAgent = $true
+
+# Connect to SWIS
+# Orion Host IP
+$hostname = "10.150.16.130"
+# Orion username
+$username = "admin"
+# Orion password
+$password = ConvertTo-SecureString -String "123" -AsPlainText -Force
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+$engineId = 1
+
+# Get local IP adress
+$ip = (
+    Get-NetIPConfiguration |
+    Where-Object {
+        $_.IPv4DefaultGateway -ne $null -and
+        $_.NetAdapter.Status -ne "Disconnected"
+    }
+).IPv4Address.IPAddress
+
+if ($deployAgent) {
+    $agentName = $ip
+    $hostname = $ip
+    # localhost username and password used to deploy agent 
+    $machineUsername = "Administrator"
+    $machinePassword = "Password1"
+    
+    Invoke-SwisVerb $swis Orion.AgentManagement.Agent Deploy @(
+        $engineId, `
+            $agentName, `
+            $hostname, `
+            $ip, `
+            $machineUsername, `
+            $machinePassword)
+}
+else {
+    # add a node
+    $newNodeProps = @{
+        IPAddress     = $ip;
+        EngineID      = $engineId;
+  
+        # SNMP v2 specific
+        ObjectSubType = "SNMP";
+
+        SNMPVersion   = 2;
+
+        DNS           = "";
+        SysName       = "";
+        Caption       = $ip;
+    
+        # === default values ===
+
+        # EntityType = 'Orion.Nodes'
+        # Caption = ''
+        # DynamicIP = false
+        # PollInterval = 120
+        # RediscoveryInterval = 30
+        # StatCollection = 10  
+    }
+
+    $newNodeUri = New-SwisObject $swis -EntityType "Orion.Nodes" -Properties $newNodeProps
+    $nodeProps = Get-SwisObject $swis -Uri $newNodeUri
+
+    # register specific pollers for the node
+    $poller = @{
+        NetObject     = "N:" + $nodeProps["NodeID"];
+        NetObjectType = "N";
+        NetObjectID   = $nodeProps["NodeID"];
+    }
+
+    # Status
+    $poller["PollerType"] = "N.Status.ICMP.Native";
+    $pollerUri = New-SwisObject $swis -EntityType "Orion.Pollers" -Properties $poller
+
+    # Response time
+    $poller["PollerType"] = "N.ResponseTime.ICMP.Native";
+    $pollerUri = New-SwisObject $swis -EntityType "Orion.Pollers" -Properties $poller
+
+    # Details
+    $poller["PollerType"] = "N.Details.SNMP.Generic";
+    $pollerUri = New-SwisObject $swis -EntityType "Orion.Pollers" -Properties $poller
+
+    # Uptime
+    $poller["PollerType"] = "N.Uptime.SNMP.Generic";
+    $pollerUri = New-SwisObject $swis -EntityType "Orion.Pollers" -Properties $poller
+
+    # CPU
+    $poller["PollerType"] = "N.Cpu.SNMP.CiscoGen3";
+    $pollerUri = New-SwisObject $swis -EntityType "Orion.Pollers" -Properties $poller
+
+    # Memory
+    $poller["PollerType"] = "N.Memory.SNMP.CiscoGen3";
+    $pollerUri = New-SwisObject $swis -EntityType "Orion.Pollers" -Properties $poller
+}

--- a/Samples/PowerShell/WindowsStartupShutdownScripts/README.md
+++ b/Samples/PowerShell/WindowsStartupShutdownScripts/README.md
@@ -1,0 +1,12 @@
+# Windows Startup and Shutdown scripts
+
+Scripts in this folder can be used to add machine to the Orion while it is starting and removing it on the machine shutdown.
+
+Additionally scripts are able to deploy agent on startup and uninstall/remove on shutdown.
+* Startup script contains flag `deploy_agent`. If this flag is set to `True` agent will be deployed. 
+* Shutdown script contains flag `should_uninstall_agent_from_node`. If this flag is set to `True` agent will be uninstalled from monitored node. Otherwise only information about agent will be removed from Orion. 
+
+## Script setup
+
+Script should be placed in startup / shutdown scripts in Local Group Policy Editor, like described in this article:
+[https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/dn789190(v=ws.11)#:~:text=computer%20shutdown%20scripts-,To%20assign%20computer%20shutdown%20scripts,Scripts%20(Startup%2FShutdown).&text=In%20Script%20Parameters%2C%20type%20any,them%20on%20the%20command%20line]

--- a/Samples/PowerShell/WindowsStartupShutdownScripts/RemoveFromOrionOnShutdown.ps1
+++ b/Samples/PowerShell/WindowsStartupShutdownScripts/RemoveFromOrionOnShutdown.ps1
@@ -1,0 +1,74 @@
+# This sample script demonstrates how to remove a node from orion and remove agnent information from orion/actually uninstall agent from a node, 
+# if the node is monitored by an agent.
+#
+# Please update the hostname and credential setup to match your configuration, and
+# information about the node you would like to add for monitoring.
+
+#Install Nuget and SwisPowerShell modules
+#On some environments we encountered an issue with executing below command, in that case try adding this command before: [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12, it will set tls version to 1.2
+Find-PackageProvider -Name "Nuget"  -RequiredVersion "2.8.5.208" | Install-PackageProvider -Force
+
+#The below line can be deleted if SwisPowerShell is already installed
+Install-Module -Name SwisPowerShell -Force
+Import-Module SwisPowerShell -Force
+
+#Decide if you want to only remove information about agent from Orion or also uninstall it from monitored node, this flag is important only when the node is monitored by agent.
+$shouldUninstallAgentFromNode = $false
+
+# Connect to SWIS
+# Orion Host IP
+$hostname = "10.150.16.71"
+# Orion username
+$username = "admin"
+# Orion password
+$password = ConvertTo-SecureString -String "123" -AsPlainText -Force
+$cred = New-Object -typename System.Management.Automation.PSCredential -argumentlist $username, $password
+$swis = Connect-Swis -host $hostname -cred $cred
+
+# Get local IP adress
+$ip=(
+    Get-NetIPConfiguration |
+    Where-Object {
+        $_.IPv4DefaultGateway -ne $null -and
+        $_.NetAdapter.Status -ne "Disconnected"
+    }
+).IPv4Address.IPAddress
+
+
+# query to get Node SWIS URI
+# interface
+$getNodeUriQuery = "SELECT Uri
+FROM Orion.Nodes
+WHERE IPAddress = '$ip'"
+
+Write-Host $getNodeUriQuery
+
+$getNodeUriQueryResults = Get-SwisData $swis $getNodeUriQuery
+
+if ($getNodeUriQueryResults.Length -gt 0) {
+    #remove node
+    Remove-SwisObject $swis $getNodeUriQueryResults
+}
+
+# query to get the agent id
+$getAgentIdQuery = "SELECT AgentId
+FROM Orion.AgentManagement.Agent
+WHERE IP = '$ip'"
+
+$getAgentIdQueryResults = Get-SwisData $swis $getAgentIdQuery
+
+#this if checks if orion contains agent information for this node
+if ($getAgentIdQueryResults.Length -gt 0) { 
+    if($shouldUninstallAgentFromNode) { 
+		#Uninstalling the agent from the node
+		$uninstallAgent = Invoke-SwisVerb $swis "Orion.AgentManagement.Agent" "Uninstall"  @(
+			$getAgentIdQueryResults
+		)
+	} 
+	else {
+		#Removing information about an agent from orion without uninstalling it
+		$deleteAgent = Invoke-SwisVerb $swis "Orion.AgentManagement.Agent" "Delete"  @(
+			$getAgentIdQueryResults
+		)
+	}		
+}


### PR DESCRIPTION
Powershell Scripts prepared by SAM team that can be used to add Windows machine to the Orion while it is starting and removing it on the Windows machine shutdown