### PR TITLE
Support for HiDPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ packages
 paket.dependencies
 paket.dependencies.locked
 .vs
+_ReSharper.Caches
 UpgradeLog.htm
 
 Samples/Java/swis-client/\.settings/

--- a/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.Designer.cs
+++ b/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.Designer.cs
@@ -962,6 +962,7 @@ namespace ScintillaNET_FindReplaceDialog
             // 
             // statusStrip
             // 
+            this.statusStrip.AutoSize = false;
             this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.lblStatus});
             this.statusStrip.Location = new System.Drawing.Point(0, 270);

--- a/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.Designer.cs
+++ b/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.Designer.cs
@@ -1614,7 +1614,6 @@ namespace ScintillaNET_FindReplaceDialog
             this.ClientSize = new System.Drawing.Size(488, 292);
             this.Controls.Add(this.tabAll);
             this.Controls.Add(this.statusStrip);
-            this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.KeyPreview = true;
             this.MaximizeBox = false;

--- a/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.Designer.cs
+++ b/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.Designer.cs
@@ -1615,6 +1615,7 @@ namespace ScintillaNET_FindReplaceDialog
             this.ClientSize = new System.Drawing.Size(488, 292);
             this.Controls.Add(this.tabAll);
             this.Controls.Add(this.statusStrip);
+            this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.KeyPreview = true;
             this.MaximizeBox = false;

--- a/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.cs
+++ b/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.cs
@@ -30,6 +30,7 @@ namespace ScintillaNET_FindReplaceDialog
 
         public FindReplaceDialog()
         {
+            SwqlStudio.Utils.DpiHelper.FixFont(this);
             InitializeComponent();
 
             _autoPosition = true;

--- a/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.cs
+++ b/Src/SwqlStudio/3rdParty/ScintillaNET-FindReplaceDialog/FindReplace/FindReplaceDialog.cs
@@ -30,7 +30,7 @@ namespace ScintillaNET_FindReplaceDialog
 
         public FindReplaceDialog()
         {
-            SwqlStudio.Utils.DpiHelper.FixFont(this);
+            this.Font = new Font("Tahoma", 8.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
             InitializeComponent();
 
             _autoPosition = true;

--- a/Src/SwqlStudio/About.Designer.cs
+++ b/Src/SwqlStudio/About.Designer.cs
@@ -37,7 +37,6 @@
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.label1.Location = new System.Drawing.Point(12, 9);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(367, 78);

--- a/Src/SwqlStudio/About.Designer.cs
+++ b/Src/SwqlStudio/About.Designer.cs
@@ -37,9 +37,9 @@
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.Location = new System.Drawing.Point(12, 9);
+            this.label1.Location = new System.Drawing.Point(14, 10);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(367, 78);
+            this.label1.Size = new System.Drawing.Size(428, 90);
             this.label1.TabIndex = 0;
             this.label1.Text = "SWQL Studio\r\nversion {0}\r\n\r\n{1}\r\n";
             // 
@@ -47,9 +47,9 @@
             // 
             this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.button1.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.button1.Location = new System.Drawing.Point(304, 90);
+            this.button1.Location = new System.Drawing.Point(355, 104);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.Size = new System.Drawing.Size(87, 27);
             this.button1.TabIndex = 1;
             this.button1.Text = "OK";
             this.button1.UseVisualStyleBackColor = true;
@@ -57,11 +57,12 @@
             // About
             // 
             this.AcceptButton = this.button1;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(391, 125);
+            this.ClientSize = new System.Drawing.Size(456, 144);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.label1);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;

--- a/Src/SwqlStudio/About.cs
+++ b/Src/SwqlStudio/About.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
+using SwqlStudio.Utils;
 
 namespace SwqlStudio
 {
@@ -8,6 +9,7 @@ namespace SwqlStudio
     {
         public About()
         {
+            DpiHelper.FixFont(this);
             InitializeComponent();
 
             var assembly = Assembly.GetEntryAssembly();

--- a/Src/SwqlStudio/About.cs
+++ b/Src/SwqlStudio/About.cs
@@ -1,7 +1,7 @@
-﻿using System.Linq;
+﻿using System.Drawing;
+using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
-using SwqlStudio.Utils;
 
 namespace SwqlStudio
 {
@@ -9,7 +9,7 @@ namespace SwqlStudio
     {
         public About()
         {
-            DpiHelper.FixFont(this);
+            this.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
             InitializeComponent();
 
             var assembly = Assembly.GetEntryAssembly();

--- a/Src/SwqlStudio/CrudTab.cs
+++ b/Src/SwqlStudio/CrudTab.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows.Forms;
 using SolarWinds.InformationService.Contract2;
 using SwqlStudio.Metadata;
+using SwqlStudio.Utils;
 
 namespace SwqlStudio
 {
@@ -18,6 +19,7 @@ namespace SwqlStudio
         {
             _operation = operation;
             InitializeComponent();
+            DpiHelper.FixRowHeight(propertiesDataGridView);
         }
 
         public Entity Entity

--- a/Src/SwqlStudio/DocumentationContent.Designer.cs
+++ b/Src/SwqlStudio/DocumentationContent.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace SwqlStudio
+﻿using SwqlStudio.Utils;
+
+namespace SwqlStudio
 {
     partial class DocumentationContent
     {
@@ -36,7 +38,7 @@
             // 
             this.itemTypeLabel.AutoSize = true;
             this.itemTypeLabel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.itemTypeLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.itemTypeLabel.Font = new System.Drawing.Font(DpiHelper.DefaultFont, System.Drawing.FontStyle.Bold);
             this.itemTypeLabel.Location = new System.Drawing.Point(0, 0);
             this.itemTypeLabel.Name = "itemTypeLabel";
             this.itemTypeLabel.Padding = new System.Windows.Forms.Padding(3);

--- a/Src/SwqlStudio/DocumentationContent.Designer.cs
+++ b/Src/SwqlStudio/DocumentationContent.Designer.cs
@@ -37,7 +37,7 @@
             this.itemTypeLabel.AutoSize = true;
             this.itemTypeLabel.Dock = System.Windows.Forms.DockStyle.Top;
             this.itemTypeLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.itemTypeLabel.Location = new System.Drawing.Point(5, 5);
+            this.itemTypeLabel.Location = new System.Drawing.Point(0, 0);
             this.itemTypeLabel.Name = "itemTypeLabel";
             this.itemTypeLabel.Padding = new System.Windows.Forms.Padding(3);
             this.itemTypeLabel.Size = new System.Drawing.Size(6, 19);
@@ -47,10 +47,10 @@
             // 
             this.docTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.docTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.docTextBox.Location = new System.Drawing.Point(5, 24);
+            this.docTextBox.Location = new System.Drawing.Point(0, 19);
             this.docTextBox.Name = "docTextBox";
             this.docTextBox.ReadOnly = true;
-            this.docTextBox.Size = new System.Drawing.Size(274, 232);
+            this.docTextBox.Size = new System.Drawing.Size(284, 242);
             this.docTextBox.TabIndex = 3;
             this.docTextBox.Text = "";
             // 
@@ -62,7 +62,6 @@
             this.Controls.Add(this.docTextBox);
             this.Controls.Add(this.itemTypeLabel);
             this.Name = "DocumentationContent";
-            this.Padding = new System.Windows.Forms.Padding(5);
             this.Text = "Documentation";
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/Src/SwqlStudio/DocumentationContent.cs
+++ b/Src/SwqlStudio/DocumentationContent.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Forms;
+using SwqlStudio.Utils;
 using WeifenLuo.WinFormsUI.Docking;
 
 namespace SwqlStudio
@@ -7,6 +8,7 @@ namespace SwqlStudio
     {
         public DocumentationContent()
         {
+            DpiHelper.FixFont(this);
             InitializeComponent();
         }
 

--- a/Src/SwqlStudio/EntityClassGraphForm.cs
+++ b/Src/SwqlStudio/EntityClassGraphForm.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Windows.Forms;
 using SolarWinds.InformationService.InformationServiceClient;
+using SwqlStudio.Utils;
 
 namespace SwqlStudio
 {
@@ -8,6 +9,7 @@ namespace SwqlStudio
     {
         public EntityClassGraphForm(EntityClassGraph entityClassGraph)
         {
+            DpiHelper.FixFont(this);
             InitializeComponent();
 
             LoadTree(entityClassGraph);

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -39,6 +39,7 @@ namespace SwqlStudio
 
         public MainForm()
         {
+            DpiHelper.FixFont(this);
             InitializeComponent();
 
             InitializeDockPanel();

--- a/Src/SwqlStudio/NewConnection.cs
+++ b/Src/SwqlStudio/NewConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using SwqlStudio.Utils;
 
 namespace SwqlStudio
 {
@@ -7,6 +8,7 @@ namespace SwqlStudio
     {
         public NewConnection()
         {
+            DpiHelper.FixFont(this);
             InitializeComponent();
 
             cmbServer.Items.AddRange(ConnectionHistory.PreviousServers);

--- a/Src/SwqlStudio/ObjectExplorer/ObjectExplorer.cs
+++ b/Src/SwqlStudio/ObjectExplorer/ObjectExplorer.cs
@@ -38,7 +38,7 @@ namespace SwqlStudio.ObjectExplorer
         private ImageList objectExplorerImageList;
         private System.ComponentModel.IContainer components;
         private TreeNode _dragNode;
-        private readonly TreeNodesBuilder treeNodesBuilder = new TreeNodesBuilder(DefaultFont);
+        private readonly TreeNodesBuilder treeNodesBuilder = new TreeNodesBuilder(DpiHelper.DefaultFont);
         public event TreeViewEventHandler SelectionChanged;
         public ITabsFactory TabsFactory { get; set; }
 

--- a/Src/SwqlStudio/QueryParameters.cs
+++ b/Src/SwqlStudio/QueryParameters.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using SolarWinds.InformationService.Contract2;
+using SwqlStudio.Utils;
 using WeifenLuo.WinFormsUI.Docking;
 
 namespace SwqlStudio
@@ -27,7 +28,9 @@ namespace SwqlStudio
 
         public QueryParameters()
         {
+            DpiHelper.FixFont(this);
             InitializeComponent();
+            DpiHelper.FixRowHeight(parametersGrid);
             parametersGrid.DataSource = new BindingList<QueryVariable>();
             AllowSetParameters = true;
         }

--- a/Src/SwqlStudio/QueryTab.cs
+++ b/Src/SwqlStudio/QueryTab.cs
@@ -15,6 +15,7 @@ using SwqlStudio.Metadata;
 using SwqlStudio.Playback;
 using SwqlStudio.Properties;
 using SwqlStudio.Subscriptions;
+using SwqlStudio.Utils;
 
 namespace SwqlStudio
 {
@@ -62,6 +63,8 @@ namespace SwqlStudio
         {
             InitializeComponent();
             nullFont = new Font(dataGridView1.DefaultCellStyle.Font, dataGridView1.DefaultCellStyle.Font.Style | FontStyle.Italic);
+            DpiHelper.FixRowHeight(dataGridView1);
+            DpiHelper.FixRowHeight(dataGridView2);
             ShowTabs(Tabs.Results);
             Disposed += QueryTabDisposed;
             AddRunContextMenu();
@@ -476,9 +479,9 @@ namespace SwqlStudio
             }
         }
 
-        private static void AutoResizeColumns(DataGridView grid)
+        private void AutoResizeColumns(DataGridView grid)
         {
-            const int maxSize = 200;
+            int maxSize = base.LogicalToDeviceUnits(200);
             const int widthFudgeFactor = 25;
 
             int[] preferredSizes = new int[grid.ColumnCount];

--- a/Src/SwqlStudio/TabTemplate.cs
+++ b/Src/SwqlStudio/TabTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Forms;
+using SwqlStudio.Utils;
 
 namespace SwqlStudio
 {
@@ -19,6 +20,11 @@ namespace SwqlStudio
         public virtual bool AllowsChangeConnection
         {
             get { return true; }
+        }
+
+        public TabTemplate()
+        {
+            DpiHelper.FixFont(this);
         }
     }
 }

--- a/Src/SwqlStudio/Utils/DpiHelper.cs
+++ b/Src/SwqlStudio/Utils/DpiHelper.cs
@@ -1,0 +1,35 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace SwqlStudio.Utils
+{
+    internal static class DpiHelper
+    {
+        /// <summary>
+        /// Sets the currently used system UI font as the default font for the <paramref name="control"/>
+        /// </summary>
+        /// <param name="control">Usually a <see cref="Form"/></param>
+        /// <remarks>This is needed because dimensions of the default font are used to calculate a proper DPI scaling ratio of child elements of the <paramref name="control"/>.
+        /// And the .Net Framework uses "Microsoft Sans Serif", 8.25F" from Windows 2.0, regardless of what the OS actually uses. This messes up the calculation.
+        /// <para>This has been reportedly fixed in .Net Core and .Net 5.</para></remarks>
+        public static void FixFont(Control control)
+        {
+            control.Font = SystemFonts.MessageBoxFont;
+        }
+
+        /// <summary>
+        /// Adjusts the default row height in a <see cref="DataGridView"/>
+        /// </summary>
+        /// <remarks>The default row height is defined as the height of the default font + 9 pixels.
+        /// However, because the default font in .Net Framework is "Microsoft Sans Serif", 8.25F", it's too small for fonts like "Segoe UI, 9F",
+        /// especially when DPI scaling is involved.
+        /// <para>This method, when called after <see cref="FixFont"/>, forces the recalculation of the height.</para>
+        /// <para>This has been reportedly fixed in .Net Core and .Net 5.</para></remarks>
+        public static void FixRowHeight(DataGridView dataGridView)
+        {
+            // Instead of "dataGridView.DefaultCellStyle.Font.Height" we could just hardcode "SystemFonts.MessageBoxFont". That way, this method would not depend
+            // on a previous call to "FixFont". But this is a bit more universal solution.
+            dataGridView.RowTemplate.Height = dataGridView.DefaultCellStyle.Font.Height + 9;
+        }
+    }
+}

--- a/Src/SwqlStudio/Utils/DpiHelper.cs
+++ b/Src/SwqlStudio/Utils/DpiHelper.cs
@@ -3,33 +3,45 @@ using System.Windows.Forms;
 
 namespace SwqlStudio.Utils
 {
+    /// <summary>
+    /// A helper class for supporting font and DPI scaling
+    /// </summary>
+    /// <remarks>
+    /// <para>This dimensions of the default font are used to calculate a proper DPI scaling ratio of elements. .Net Framework tries to use "MS Sans Serif"
+    /// from Windows 3.1, which isn't available anymore. So the system automatically replaces it with "Microsoft Sans Serif", or sometimes with "Tahoma".
+    /// But those are too old and don't match with Windows UI fonts. And if there are elements using also other fonts, like "Segoe UI", it messes up the calculation.
+    /// That can happen especially when a different font is used for rendering than for the DPI scaling calculation.</para>
+    /// <para>This should not be needed anymore in .Net Core 3.1 and .Net 5: https://github.com/dotnet/winforms/pull/656 </para>
+    /// </remarks>
     internal static class DpiHelper
     {
         /// <summary>
-        /// Sets the currently used system UI font as the default font for the <paramref name="control"/>
+        /// The default font used in SWQL Studio dialogs
+        /// </summary>
+        /// <remarks>Returns the default font used by the OS.</remarks>
+        /// <value><see cref="SystemFonts.MessageBoxFont"/></value>
+        public static readonly Font DefaultFont = SystemFonts.MessageBoxFont;
+
+        /// <summary>
+        /// Sets the <see cref="DefaultFont"/> as the default font for the <paramref name="control"/>
         /// </summary>
         /// <param name="control">Usually a <see cref="Form"/></param>
-        /// <remarks>This is needed because dimensions of the default font are used to calculate a proper DPI scaling ratio of the <paramref name="control"/>'s child elements.
-        /// <para>.Net Framework tries to use "MS Sans Serif" from Windows 3.1, which isn't available anymore. So the system automatically replaces it with "Microsoft Sans Serif",
-        /// or sometimes with "Tahoma". But those are also too old. And if there are elements using also other fonts, like "Segoe UI", it messes up the calculation.
-        /// So, instead of hard-coding a specific font, let's use whatever the OS prefers to use for its own dialogs.</para>
-        /// <para>This has been reportedly fixed in .Net Core and .Net 5.</para></remarks>
+        /// <remarks>This is needed to correctly calculate a proper DPI scaling ratio of the <paramref name="control"/> and its child elements.
+        /// It forces the <paramref name="control"/> to sync the fonts used for its rendering and DPI scaling calculation.
+        /// <para>This should be called in the <paramref name="control"/>'s constructor.</para></remarks>
         public static void FixFont(Control control)
         {
-            control.Font = SystemFonts.MessageBoxFont;
+            control.Font = DefaultFont;
         }
 
         /// <summary>
         /// Adjusts the default row height in a <see cref="DataGridView"/>
         /// </summary>
         /// <remarks>The default row height is defined as the height of the default font + 9 pixels.
-        /// However, because the default font in .Net Framework is "MS Sans Serif 8.25F", it's too small for fonts like "Segoe UI, 9F",
-        /// especially when DPI scaling is involved.
-        /// <para>This method, when called after <see cref="FixFont"/>, forces the recalculation of the height.</para>
-        /// <para>This has been reportedly fixed in .Net Core and .Net 5.</para></remarks>
+        /// This method, when called after <see cref="FixFont"/>, forces the recalculation of the height.</remarks>
         public static void FixRowHeight(DataGridView dataGridView)
         {
-            // Instead of "dataGridView.DefaultCellStyle.Font.Height" we could just hard-code "SystemFonts.MessageBoxFont". That way, this method would not depend
+            // Instead of "dataGridView.DefaultCellStyle.Font.Height" we could just hard-code "DefaultFont". That way, this method would not depend
             // on a previous call to "FixFont". But this is a bit more universal solution.
             dataGridView.RowTemplate.Height = dataGridView.DefaultCellStyle.Font.Height + 9;
         }

--- a/Src/SwqlStudio/Utils/DpiHelper.cs
+++ b/Src/SwqlStudio/Utils/DpiHelper.cs
@@ -18,9 +18,9 @@ namespace SwqlStudio.Utils
         /// <summary>
         /// The default font used in SWQL Studio dialogs
         /// </summary>
-        /// <remarks>Returns the default font used by the OS.</remarks>
-        /// <value><see cref="SystemFonts.MessageBoxFont"/></value>
-        public static readonly Font DefaultFont = SystemFonts.MessageBoxFont;
+        /// <remarks>Returns the default .Net font.</remarks>
+        /// <value>Microsoft Sans Serif, 8.25F</value>
+        public static readonly Font DefaultFont = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
 
         /// <summary>
         /// Sets the <see cref="DefaultFont"/> as the default font for the <paramref name="control"/>

--- a/Src/SwqlStudio/Utils/DpiHelper.cs
+++ b/Src/SwqlStudio/Utils/DpiHelper.cs
@@ -9,8 +9,10 @@ namespace SwqlStudio.Utils
         /// Sets the currently used system UI font as the default font for the <paramref name="control"/>
         /// </summary>
         /// <param name="control">Usually a <see cref="Form"/></param>
-        /// <remarks>This is needed because dimensions of the default font are used to calculate a proper DPI scaling ratio of child elements of the <paramref name="control"/>.
-        /// And the .Net Framework uses "Microsoft Sans Serif", 8.25F" from Windows 2.0, regardless of what the OS actually uses. This messes up the calculation.
+        /// <remarks>This is needed because dimensions of the default font are used to calculate a proper DPI scaling ratio of the <paramref name="control"/>'s child elements.
+        /// <para>.Net Framework tries to use "MS Sans Serif" from Windows 3.1, which isn't available anymore. So the system automatically replaces it with "Microsoft Sans Serif",
+        /// or sometimes with "Tahoma". But those are also too old. And if there are elements using also other fonts, like "Segoe UI", it messes up the calculation.
+        /// So, instead of hard-coding a specific font, let's use whatever the OS prefers to use for its own dialogs.</para>
         /// <para>This has been reportedly fixed in .Net Core and .Net 5.</para></remarks>
         public static void FixFont(Control control)
         {
@@ -21,13 +23,13 @@ namespace SwqlStudio.Utils
         /// Adjusts the default row height in a <see cref="DataGridView"/>
         /// </summary>
         /// <remarks>The default row height is defined as the height of the default font + 9 pixels.
-        /// However, because the default font in .Net Framework is "Microsoft Sans Serif", 8.25F", it's too small for fonts like "Segoe UI, 9F",
+        /// However, because the default font in .Net Framework is "MS Sans Serif 8.25F", it's too small for fonts like "Segoe UI, 9F",
         /// especially when DPI scaling is involved.
         /// <para>This method, when called after <see cref="FixFont"/>, forces the recalculation of the height.</para>
         /// <para>This has been reportedly fixed in .Net Core and .Net 5.</para></remarks>
         public static void FixRowHeight(DataGridView dataGridView)
         {
-            // Instead of "dataGridView.DefaultCellStyle.Font.Height" we could just hardcode "SystemFonts.MessageBoxFont". That way, this method would not depend
+            // Instead of "dataGridView.DefaultCellStyle.Font.Height" we could just hard-code "SystemFonts.MessageBoxFont". That way, this method would not depend
             // on a previous call to "FixFont". But this is a bit more universal solution.
             dataGridView.RowTemplate.Height = dataGridView.DefaultCellStyle.Font.Height + 9;
         }


### PR DESCRIPTION
SWQL Studio in version 3.0 declares support for high-DPI displays. However, it doesn't really work:

<img width="1920" alt="Comparison: 4K display with 150% DPI" src="https://user-images.githubusercontent.com/37192399/108104175-d2fd5380-703f-11eb-9cc3-a171e07d5fdd.png">

The screenshot comes from a 4K display with 150% DPI scaling.

As you can see in the middle, the rendering of the current version is inconsistent and the app is barely usable.

The example on the right is the same build of SWQL Studio, just with reverted #266 (disabled in config). While blurry, the rendering is consistent and everything works as it should.

The example on the left is the result of this PR. The rendering is correct and sharp. However, spacing between elements is visibly bigger and a few icons are smaller than they should be.

With additional work, that could be improved. But I wanted to implement just the bare minimum to support high-resolution displays. .NET Framework 4.8 doesn't have a great support for this feature and implementing multiple layouts/icon sets for different DPI scalings seemed too much. .NET 5 might help with that. But if anyone has time for it, simply playing with margins/paddings/... could improve the layout a bit.

On displays with 100% DPI scaling the app still looks mostly unchanged. Just spacing between elements is slightly bigger: _(opening the screenshots in a separate tab will show the difference)_
Current version - query:
![Current version - query](https://user-images.githubusercontent.com/37192399/108104523-44d59d00-7040-11eb-9442-f8939978dd38.png)
PR version - query:
![PR version - query](https://user-images.githubusercontent.com/37192399/108104545-499a5100-7040-11eb-8324-195e43e2aec3.png)
Current version - search:
![Current version - search](https://user-images.githubusercontent.com/37192399/108104558-4f903200-7040-11eb-9df9-0fd4268ce33d.png)
PR version - search:
![PR version - search](https://user-images.githubusercontent.com/37192399/108104571-53bc4f80-7040-11eb-9ecb-4867b0073484.png)

