### PR TITLE
Update wixproj to load in VS2019

### DIFF
--- a/Src/Install/Install.wixproj
+++ b/Src/Install/Install.wixproj
@@ -56,11 +56,9 @@
     <Content Include="GlobalVariables.wxi" />
     <Content Include="packages.config" />
   </ItemGroup>
-  <PropertyGroup>
-    <WixToolPath>$(SolutionDir)packages\WiX.Toolset.3.9.1006.0\tools\wix\</WixToolPath>
-    <WixTargetsPath>$(WixToolPath)wix.targets</WixTargetsPath>
-    <WixTasksPath>$(WixToolPath)WixTasks.dll</WixTasksPath>
-  </PropertyGroup>
+<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+<Import Project="$(WixCATargetsPath)" Condition=" '$(WixCATargetsPath)' != '' " />
+<Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets" Condition=" '$(WixCATargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.CA.targets') " />
   <Import Project="$(WixTargetsPath)" />
   <!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.


### PR DESCRIPTION
Fix to load project in VS2019, change related to newer MSBuild.

Source: [https://github.com/wixtoolset/issues/issues/5804#issuecomment-532663590](https://github.com/wixtoolset/issues/issues/5804#issuecomment-532663590)
