### PR TITLE
Updated SwqlStudio.csproj to use Serilog for logging

### DIFF
--- a/Src/Install/Product.wxs
+++ b/Src/Install/Product.wxs
@@ -120,11 +120,26 @@
                 <File Id="SwqlStudioExe" Source="$(var.OutputDir)\SwqlStudio.exe" />
                 <File Source="$(var.OutputDir)\SwqlStudio.exe.config" />
                 <File Source="$(var.OutputDir)\log4net.dll" />
+                <File Source="$(var.OutputDir)\Microsoft.Bcl.AsyncInterfaces.dll" />
+                <File Source="$(var.OutputDir)\Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+                <File Source="$(var.OutputDir)\Microsoft.Extensions.DependencyInjection.dll" />
+                <File Source="$(var.OutputDir)\Microsoft.Extensions.Logging.Abstractions.dll" />
+                <File Source="$(var.OutputDir)\Microsoft.Extensions.Logging.dll" />
+                <File Source="$(var.OutputDir)\Microsoft.Extensions.Options.dll" />
+                <File Source="$(var.OutputDir)\Microsoft.Extensions.Primitives.dll" />
                 <File Source="$(var.OutputDir)\ScintillaNet.dll" />
+                <File Source="$(var.OutputDir)\Serilog.dll" />
+                <File Source="$(var.OutputDir)\Serilog.Extensions.Logging.dll" />
+                <File Source="$(var.OutputDir)\Serilog.Sinks.File.dll" />
                 <File Source="$(var.OutputDir)\SolarWinds.SDK.Swis.Contract.dll" />
                 <File Source="$(var.OutputDir)\SolarWinds.Logging.dll" />
+                <File Source="$(var.OutputDir)\System.Buffers.dll" />
                 <File Source="$(var.OutputDir)\Security.Cryptography.dll" />
                 <File Source="$(var.OutputDir)\System.Configuration.ConfigurationManager.dll" />
+                <File Source="$(var.OutputDir)\System.Diagnostics.DiagnosticSource.dll" />
+                <File Source="$(var.OutputDir)\System.Memory.dll" />
+                <File Source="$(var.OutputDir)\System.Numerics.Vectors.dll" />
+                <File Source="$(var.OutputDir)\System.Runtime.CompilerServices.Unsafe.dll" />
                 <File Source="$(var.OutputDir)\System.Security.AccessControl.dll" />
                 <File Source="$(var.OutputDir)\System.Security.Permissions.dll" />
                 <File Source="$(var.OutputDir)\System.Security.Principal.Windows.dll" />
@@ -133,6 +148,8 @@
                 <File Source="$(var.OutputDir)\System.ServiceModel.NetTcp.dll" />
                 <File Source="$(var.OutputDir)\System.ServiceModel.Primitives.dll" />
                 <File Source="$(var.OutputDir)\System.ServiceModel.Security.dll" />
+                <File Source="$(var.OutputDir)\System.Threading.Tasks.Extensions.dll" />
+                <File Source="$(var.OutputDir)\System.ValueTuple.dll" />
                 <File Source="$(var.OutputDir)\WeifenLuo.WinFormsUI.Docking.dll" />
                 <File Source="$(var.OutputDir)\WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
               </Component>

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.ServiceModel;
 using System.Windows.Forms;
+using Microsoft.Extensions.Logging;
 using SolarWinds.InformationService.Contract2;
 using SolarWinds.InformationService.InformationServiceClient;
 using SwqlStudio.Metadata;
@@ -17,7 +18,7 @@ namespace SwqlStudio
         UseSynchronizationContext = false)]
     internal partial class MainForm : Form, IApplicationService
     {
-        private static readonly SolarWinds.Logging.Log log = new SolarWinds.Logging.Log();
+        private static readonly ILogger<MainForm> log = Program.LoggerFactory.CreateLogger<MainForm>();
         private ServerList serverList;
         private readonly BindingList<ConnectionInfo> connectionsDataSource = new BindingList<ConnectionInfo>();
         private ConnectionsManager connectionsManager;
@@ -137,7 +138,7 @@ namespace SwqlStudio
             }
             catch (Exception ex)
             {
-                log.Error("Failed to connect", ex);
+                log.LogError(ex, "Failed to connect");
                 var msg = $"Unable to connect to Information Service.\n{ex.Message}";
                 MessageBox.Show(msg, "Connection Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
@@ -296,7 +297,7 @@ namespace SwqlStudio
             }
             catch (FaultException<InfoServiceFaultContract> ex)
             {
-                log.Error("Failed to connect", ex);
+                log.LogError(ex, "Failed to connect");
                 errorMsg = ex.Detail.Message;
             }
             catch (Exception ex)

--- a/Src/SwqlStudio/ObjectExplorer/ObjectExplorer.cs
+++ b/Src/SwqlStudio/ObjectExplorer/ObjectExplorer.cs
@@ -8,7 +8,7 @@ using System.ServiceModel.Security;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
-using SolarWinds.Logging;
+using Microsoft.Extensions.Logging;
 using SwqlStudio.Filtering;
 using SwqlStudio.Metadata;
 using SwqlStudio.Utils;
@@ -20,7 +20,7 @@ namespace SwqlStudio.ObjectExplorer
 {
     internal class ObjectExplorer : Control
     {
-        private static readonly Log log = new Log();
+        private static readonly ILogger<ObjectExplorer> log = Program.LoggerFactory.CreateLogger<ObjectExplorer>();
 
         private readonly SearchTextBox _treeSearch;
         private readonly TreeView _tree;
@@ -411,7 +411,7 @@ namespace SwqlStudio.ObjectExplorer
             }
             catch (ApplicationException e)
             {
-                log.Info("Exception checking if we can create subscriptions.", e);
+                log.LogInformation(e, "Exception checking if we can create subscriptions.");
             }
 
             if (dt != null && (dt.Rows.Count == 1 && dt.Columns.Count == 1))

--- a/Src/SwqlStudio/Playback/PlaybackManager.cs
+++ b/Src/SwqlStudio/Playback/PlaybackManager.cs
@@ -5,12 +5,13 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace SwqlStudio.Playback
 {
     internal class PlaybackManager
     {
-        private static readonly SolarWinds.Logging.Log log = new SolarWinds.Logging.Log();
+        private static readonly ILogger<PlaybackManager> log = Program.LoggerFactory.CreateLogger<PlaybackManager>();
 
         public static void StartPlayback(PlaybackItem file)
         {
@@ -27,7 +28,7 @@ namespace SwqlStudio.Playback
                     var playbackItem = f as PlaybackItem;
                     if (playbackItem != null)
                     {
-                        log.DebugFormat("Playing back file: {0}", playbackItem.FileName);
+                        log.LogDebug("Playing back file: {fileName}", playbackItem.FileName);
                         var sb = new StringBuilder();
                         using (var sr = new StreamReader(playbackItem.FileName))
                         {
@@ -53,7 +54,7 @@ namespace SwqlStudio.Playback
             }
             catch (Exception e)
             {
-                log.Error(e);
+                log.LogError(e, "Error while running playback file.");
             }
         }
 

--- a/Src/SwqlStudio/ProductSpecific/CustomCertificateValidator.cs
+++ b/Src/SwqlStudio/ProductSpecific/CustomCertificateValidator.cs
@@ -1,18 +1,18 @@
 ﻿using System;
 using System.IdentityModel.Selectors;
 using System.Security.Cryptography.X509Certificates;
-using SolarWinds.Logging;
+using Microsoft.Extensions.Logging;
 using SwqlStudio.Properties;
 
 namespace SwqlStudio.ProductSpecific
 {
     public class CustomCertificateValidator : X509CertificateValidator
     {
-        private static readonly Log log = new Log();
+        private static readonly ILogger<CustomCertificateValidator> log = Program.LoggerFactory.CreateLogger<CustomCertificateValidator>();
 
         public override void Validate(X509Certificate2 certificate)
         {
-            log.InfoFormat("Allowing certificate {0}", certificate);
+            log.LogInformation("Allowing certificate {certificate}", certificate);
             X509Certificate2Collection certs = LoadCertificates();
             ValidateCertPresent(certs);
             X509Certificate2 cert = certs[0];

--- a/Src/SwqlStudio/Subscriptions/SubscriptionManager.cs
+++ b/Src/SwqlStudio/Subscriptions/SubscriptionManager.cs
@@ -4,9 +4,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.ServiceModel;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using SolarWinds.InformationService.Contract2;
 using SolarWinds.InformationService.Contract2.PubSub;
-using SolarWinds.Logging;
 
 namespace SwqlStudio.Subscriptions
 {
@@ -14,7 +14,7 @@ namespace SwqlStudio.Subscriptions
 
     public class SubscriptionManager : INotificationSubscriber
     {
-        private readonly static Log log = new Log();
+        private readonly static ILogger<SubscriptionManager> log = Program.LoggerFactory.CreateLogger<SubscriptionManager>();
         private readonly ConcurrentDictionary<ConnectionInfo, SubscriptionInfo> proxies = new ConcurrentDictionary<ConnectionInfo, SubscriptionInfo>();
 
         private readonly SubscriptionServiceHost _subscriptionListener;
@@ -39,12 +39,12 @@ namespace SwqlStudio.Subscriptions
             }
             catch (FaultException<InfoServiceFaultContract> ex)
             {
-                log.Debug($"Unable to unsubscribe {subscriptionUri}.  Must have been deleted already", ex);
+                log.LogDebug(ex, $"Unable to unsubscribe {subscriptionUri}.  Must have been deleted already");
             }
             catch (CommunicationException ex)
             {
                 // also in case connection already disposed
-                log.Debug("Unable to unsubscribe due to communication error.", ex);
+                log.LogDebug(ex, "Unable to unsubscribe due to communication error.");
             }
         }
 

--- a/Src/SwqlStudio/SwqlStudio.csproj
+++ b/Src/SwqlStudio/SwqlStudio.csproj
@@ -27,6 +27,9 @@
     <PackageReference Include="DockPanelSuite" Version="3.0.6" />
     <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.0.6" />
     <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -59,7 +62,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Contract\SolarWinds.InformationService.Contract.csproj" />
-    <ProjectReference Include="..\Logging\SolarWinds.Logging.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/SwqlStudio/TabsFactory.cs
+++ b/Src/SwqlStudio/TabsFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Forms;
+using Microsoft.Extensions.Logging;
 using SwqlStudio.Metadata;
 using SwqlStudio.Properties;
 using WeifenLuo.WinFormsUI.Docking;
@@ -9,7 +10,7 @@ namespace SwqlStudio
 {
     internal class TabsFactory : ITabsFactory
     {
-        private static readonly SolarWinds.Logging.Log log = new SolarWinds.Logging.Log();
+        private static readonly ILogger<TabsFactory> log = Program.LoggerFactory.CreateLogger<TabsFactory>();
 
         private readonly ServerList serverList;
         private readonly QueriesDockPanel dockPanel;
@@ -45,7 +46,7 @@ namespace SwqlStudio
             }
             catch (Exception ex)
             {
-                log.Error("Failed to connect", ex);
+                log.LogError(ex, "Failed to connect");
                 var msg = $"Unable to connect to Information Service.\n{ex.Message}";
                 MessageBox.Show(msg, "Connection Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }

--- a/Src/SwqlStudio/app.config
+++ b/Src/SwqlStudio/app.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="System.Configuration.IgnoreSectionHandler"/>
     <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
       <section name="SwqlStudio.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
     </sectionGroup>
@@ -214,31 +213,4 @@
       </endpointBehaviors>
     </behaviors>
   </system.serviceModel>
-  <log4net>
-    <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="[%thread] %-5level: %message - %logger{1}%newline"/>
-      </layout>
-    </appender>
-    <appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender">
-      <file value="${ALLUSERSPROFILE}\Application Data\SolarWinds\Logs\SwqlStudio.log"/>
-      <appendToFile value="false"/>
-      <rollingStyle value="Size"/>
-      <maxSizeRollBackups value="5"/>
-      <maximumFileSize value="5MB"/>
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger - %message%newline"/>
-      </layout>
-    </appender>
-    <appender name="OutputDebugStringAppender" type="log4net.Appender.OutputDebugStringAppender">
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger - %message%newline"/>
-      </layout>
-    </appender>
-    <root>
-      <level value="DEBUG"/>
-      <appender-ref ref="RollingLogFileAppender"/>
-      <!--<appender-ref ref="ConsoleAppender" />-->
-    </root>
-  </log4net>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>


### PR DESCRIPTION
Updated SwqlStudio.csproj to eliminate the SolarWinds.Logging dependency (and a transitive dependency on log4net.  It is configured instead to use Microsoft.Extensions.Logging and Serilog for logging.  The log file path is no longer configurable via the App.config file in this approach.  Updated the installer to add the new dependencies, including transitive dependencies.  The SolarWinds.Logging and log4net assemblies are still deployed since SolarWinds.InformationService.Contract still depends on them.  This is not ready for merging.