### PR TITLE
Chocolatey updates for the 3.0.336 release

### DIFF
--- a/Chocolatey/OrionSDK.nuspec
+++ b/Chocolatey/OrionSDK.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>orionsdk</id>
     <title>SolarWinds Orion SDK</title>
-    <version>3.0.0.290</version>
+    <version>3.0.336</version>
     <authors>SolarWinds</authors>
     <owners>Tim Danner</owners>
     <summary>Software development kit for the SolarWinds Orion platform.</summary>
@@ -14,7 +14,7 @@
     <packageSourceUrl>https://github.com/solarwinds/OrionSDK/blob/master/Chocolatey/OrionSDK.nuspec</packageSourceUrl>
     <!-- <projectSourceUrl>https://github.com/solarwinds/OrionSDK</projectSourceUrl> -->
     <docsUrl>https://github.com/solarwinds/OrionSDK/wiki</docsUrl>
-    <mailingListUrl>https://thwack.solarwinds.com/community/labs_tht/orion-sdk</mailingListUrl>
+    <mailingListUrl>https://thwack.solarwinds.com/product-forums/the-orion-platform/f/orion-sdk</mailingListUrl>
     <bugTrackerUrl>https://github.com/solarwinds/OrionSDK/issues</bugTrackerUrl>
     <tags>orionsdk admin solarwinds</tags>
     <copyright>Copyright © SolarWinds Worldwide, LLC.  All rights reserved.</copyright>
@@ -26,20 +26,12 @@
       <dependency id="" />
     </dependencies>-->
     <releaseNotes><![CDATA[
-# v3.0.0.290
+# v3.0.336
 
-This release includes several enhancements and bug fixes.  Note that this release now requires .NET Framework 4.8.
+This release includes two bug fixes since the v3.0.0.309-beta release and some minor code cleanup changes:
 
-- Added support for reading documentation from metadata - by @jirkapok
-- Added support for filtering, based on obsolescence - by @gglogowski
-- Added support for pause button for activity monitor - by @etichy 
-- Fixed parameter copy-paste - by @jirkapok
-- Fixed annoying save dialog to display just once - @jirkapok 
-- Enabled high DPI support - @tdanner 
-- SQL's DateTime now shows full precision - @martin-lacina-swi 
-- Fixed intellisense, added Ctrl+Space shortcut to show intellisense - @jirkapok 
-- Migrated to .NET48 - @danjagnow 
-- Copy text from query window formatted - @nothrow 
+* Find and Replace dialog fixes #274
+* Fixing autocomplete #278 
 ]]></releaseNotes>
     <!--<provides></provides>-->
   </metadata>

--- a/Chocolatey/tools/chocolateyInstall.ps1
+++ b/Chocolatey/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'orionsdk'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://github.com/solarwinds/OrionSDK/releases/download/v3.0/OrionSDK.msi'
+$url        = 'https://github.com/solarwinds/OrionSDK/releases/download/v3.0.336/OrionSDK.msi'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -16,7 +16,7 @@ $packageArgs = @{
   validExitCodes= @(0, 3010, 1641)
 
   softwareName  = 'orionsdk*'
-  checksum      = 'F5748296C51290DF392C1628265C81BD34B95B5B54752AAD7654B33430F1B184'
+  checksum      = '23263EFC4F847B7C3766AD64131E74FDDECB0B0D5F642088CE42FBFB60D24EC4'
   checksumType  = 'sha256'
 }
 


### PR DESCRIPTION
Updated **OrionSDK.nuspec** and **chocolateyInstall.ps1** for the [3.0.336 release](https://github.com/solarwinds/OrionSDK/releases/tag/v3.0.336) of the SDK.