### PR TITLE
NuGet updates

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageRestore>
+    <add key="enabled" value="True" />
+  </packageRestore>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
+  <trustedSigners>
+    <author name="microsoft">
+      <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </author>
+    <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+      <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </repository>
+  </trustedSigners>
+</configuration>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -15,7 +15,6 @@
 
     <!-- we do want to pack only specific assemblies -->
     <IsPackable>false</IsPackable>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <!-- Include Copyright information -->

--- a/Src/Directory.Packages.props
+++ b/Src/Directory.Packages.props
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="1.3.0" />
     <PackageVersion Include="DockPanelSuite" Version="3.0.6" />

--- a/Src/Directory.Packages.props
+++ b/Src/Directory.Packages.props
@@ -4,23 +4,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="1.3.0" />
+    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="DockPanelSuite" Version="3.0.6" />
     <PackageVersion Include="DockPanelSuite.ThemeVS2015" Version="3.0.6" />
-    <PackageVersion Include="FluentAssertions" Version="5.10.3" />
+    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="jacobslusser.ScintillaNET" Version="3.6.3" />
-    <PackageVersion Include="log4net" Version="2.0.12" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageVersion Include="NUnit" Version="3.9.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.0" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageVersion Include="System.ServiceModel.Duplex" Version="4.7.0" />
-    <PackageVersion Include="System.ServiceModel.Http" Version="4.7.0" />
-    <PackageVersion Include="System.ServiceModel.NetTcp" Version="4.7.0" />
-    <PackageVersion Include="System.ServiceModel.Primitives" Version="4.7.0" />
-    <PackageVersion Include="System.ServiceModel.Security" Version="4.7.0" />
-    <PackageVersion Include="xunit" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageVersion Include="log4net" Version="2.0.15" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageVersion Include="System.ServiceModel.Duplex" Version="4.10.0" />
+    <PackageVersion Include="System.ServiceModel.Http" Version="4.10.0" />
+    <PackageVersion Include="System.ServiceModel.NetTcp" Version="4.10.0" />
+    <PackageVersion Include="System.ServiceModel.Primitives" Version="4.10.0" />
+    <PackageVersion Include="System.ServiceModel.Security" Version="4.10.0" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 </Project>

--- a/Src/Directory.Packages.props
+++ b/Src/Directory.Packages.props
@@ -1,31 +1,22 @@
 <Project>
-
-  <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="1.3.0" />
-    <PackageVersion Include="xunit" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageVersion Include="FluentAssertions" Version="5.10.3" />
-    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.0" />   
     <PackageVersion Include="DockPanelSuite" Version="3.0.6" />
     <PackageVersion Include="DockPanelSuite.ThemeVS2015" Version="3.0.6" />
+    <PackageVersion Include="FluentAssertions" Version="5.10.3" />
     <PackageVersion Include="jacobslusser.ScintillaNET" Version="3.6.3" />
-    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.0" />   
-    <PackageVersion Include="System.ServiceModel.Security" Version="4.7.0" />
     <PackageVersion Include="log4net" Version="2.0.12" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageVersion Include="NUnit" Version="3.9.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="3.9.0" />
-    
+    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.0" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageVersion Include="System.ServiceModel.Duplex" Version="4.7.0" />
     <PackageVersion Include="System.ServiceModel.Http" Version="4.7.0" />
     <PackageVersion Include="System.ServiceModel.NetTcp" Version="4.7.0" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="4.7.0" />
     <PackageVersion Include="System.ServiceModel.Security" Version="4.7.0" />
-    
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Sorted the NuGet packages listed in **Directory.Packages.props** alphabetically and removed a couple of duplicate entries (`PowerShellStandard.Library` and `System.ServiceModel.Security`).  Also removed the `TargetFramework` from this file since this varies from project to project.
- Added a simple **NuGet.config** file to enforce consistency in package sources and identify trusted signers.
- Moved the `ManagePackageVersionsCentrally` MSBuild property from **Directory.Build.props** to **Directory.Packages.props**.
- Updated most of the NuGet packages to the latest version available (ignoring pre-release).