### PR TITLE
Updated C# sample to .NET 6

### DIFF
--- a/Samples/CSharp/CSRestClient.csproj
+++ b/Samples/CSharp/CSRestClient.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.22" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/Samples/CSharp/Program.cs
+++ b/Samples/CSharp/Program.cs
@@ -16,7 +16,7 @@ namespace CSRestClient
             try
             {
                 var swisClient = new SwisClient(Hostname, Username, Password);
-                
+
                 var alertObjectId = GetOneAlert(swisClient);
                 var invokeResult = AcknowledgeAlert(swisClient, alertObjectId, "Ack from API");
                 Console.WriteLine(invokeResult);
@@ -27,11 +27,11 @@ namespace CSRestClient
             {
                 Console.WriteLine(ex);
             }
-            
+
             if (Debugger.IsAttached)
             {
                 Console.WriteLine("Press enter to exit.");
-                Console.ReadLine();                
+                Console.ReadLine();
             }
         }
 
@@ -51,7 +51,7 @@ ORDER BY TriggeredDateTime DESC";
 
         private static JToken AcknowledgeAlert(ISwisClient swisClient, int alertObjectId, string note)
         {
-            JToken invokeResult = swisClient.InvokeAsync("Orion.AlertActive", "Acknowledge", new[] {alertObjectId}, note).Result;
+            JToken invokeResult = swisClient.InvokeAsync("Orion.AlertActive", "Acknowledge", new[] { alertObjectId }, note).Result;
             return invokeResult;
         }
 

--- a/Samples/CSharp/SwisClient.cs
+++ b/Samples/CSharp/SwisClient.cs
@@ -20,13 +20,9 @@ namespace CSRestClient
 
         public SwisClient(string hostname, string username, string password)
         {
-            if (hostname == null) throw new ArgumentNullException("hostname");
-            if (username == null) throw new ArgumentNullException("username");
-            if (password == null) throw new ArgumentNullException("password");
-
-            _hostname = hostname;
-            _username = username;
-            _password = password;
+            _hostname = hostname ?? throw new ArgumentNullException(nameof(hostname));
+            _username = username ?? throw new ArgumentNullException(nameof(username));
+            _password = password ?? throw new ArgumentNullException(nameof(password));
         }
 
         public Task<JToken> QueryAsync(string query, object parameters = null)
@@ -68,7 +64,7 @@ namespace CSRestClient
 
         public Task UpdateAsync(IEnumerable<string> uris, object properties)
         {
-            return SwisCallAsync(client => client.PostAsync("BulkUpdate", MakeHttpContent(new {uris, properties})));
+            return SwisCallAsync(client => client.PostAsync("BulkUpdate", MakeHttpContent(new { uris, properties })));
         }
 
         public Task DeleteAsync(string uri)
@@ -78,7 +74,7 @@ namespace CSRestClient
 
         public Task DeleteAsync(IEnumerable<string> uris)
         {
-            return SwisCallAsync(client => client.PostAsync("BulkDelete", MakeHttpContent(new {uris})));
+            return SwisCallAsync(client => client.PostAsync("BulkDelete", MakeHttpContent(new { uris })));
         }
 
         private static HttpContent MakeHttpContent(object value)
@@ -89,11 +85,11 @@ namespace CSRestClient
 
         private async Task<JToken> SwisCallAsync(Func<HttpClient, Task<HttpResponseMessage>> doRequest)
         {
-            var handler = new WebRequestHandler
+            var handler = new HttpClientHandler
             {
                 Credentials = new NetworkCredential(_username, _password),
                 PreAuthenticate = true,
-                ServerCertificateValidationCallback = ValidateServerCertificate
+                ServerCertificateCustomValidationCallback = ValidateServerCertificate
             };
 
             using (var client = new HttpClient(handler))


### PR DESCRIPTION
Updated the C# sample in **CSRestClient.csproj** to target .NET 6 instead of .NET Framework 4.5.  Also did some minor formatting cleanup.  Also updated it to handle the case where the query for active alerts does not return any alerts.