### PR TITLE
Sanitize Credentials with Special Characters to Prevent Management Issues

### DIFF
--- a/Src/SwqlStudio/InvokeVerbTab.cs
+++ b/Src/SwqlStudio/InvokeVerbTab.cs
@@ -189,10 +189,39 @@ namespace SwqlStudio
 
                 default:
                     doc.InnerXml = text;
+                    
+                    if (arg.Type.StartsWith("System.Collections.Generic.Dictionary", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var valueElements = doc.DocumentElement.GetElementsByTagName("Value");
+
+                        foreach (XmlNode valueElement in valueElements)
+                        {
+                            ReplaceTextWithCData(valueElement);
+                        }
+                    }
+                    
                     return doc.DocumentElement;
             }
         }
 
+        private void ReplaceTextWithCData(XmlNode node)
+        {
+            if (node.HasChildNodes)
+            {
+                foreach (XmlNode childNode in node.ChildNodes)
+                {
+                    if (childNode.NodeType == XmlNodeType.Text)
+                    {
+                        XmlDocument doc = node.OwnerDocument;
+                        XmlCDataSection cdata = doc.CreateCDataSection(childNode.OuterXml);
+
+                        XmlNode parent = childNode.ParentNode;
+                        parent.ReplaceChild(cdata, childNode);
+                    }
+                }
+            }
+        }
+        
         private void webBrowser1_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)
         {
             HtmlElementCollection divs = webBrowser1.Document.GetElementsByTagName("div");


### PR DESCRIPTION
This pull request addresses an issue in the SWIS where credentials containing special characters were causing problems in managing and processing data. By converting credentials that contain problematic characters into CDATA sections, we ensure proper handling and prevent XML parsing errors without altering or removing the actual content. This update improves stability and compatibility when working with credentials that contain special characters, such as invalid XML characters.
(internal tracking ID: OO-33518)