### PR TITLE
Extend IIS/Exchange scripts with configuration functionality

### DIFF
--- a/Samples/PowerShell/SAM.AppInsightAutomation/CreateAppInsightForExchange.ps1
+++ b/Samples/PowerShell/SAM.AppInsightAutomation/CreateAppInsightForExchange.ps1
@@ -49,15 +49,15 @@ $shouldConfigureExchangeServer = $true
 if ($shouldConfigureExchangeServer) {
 	Write-Host "Scheduling Exchange configuration for Application ID '$applicationId'."
 
-$maxRetries = 5
+$maxRetries = 10
 $retryCount = 0
 $executionKey = (Invoke-SwisVerb $swis "Orion.APM.Exchange.Application" "ScheduleConfiguration" @($applicationId, $credentialSetId)).InnerText
 
 while ($retryCount -lt $maxRetries) {
+    Start-Sleep -Seconds 15  # Wait for a few seconds before retrying
 	$configResult = (Invoke-SwisVerb $swis "Orion.APM.Exchange.Application" "GetConfigurationResult" @($executionKey)).InnerText
 	
 	Write-Host "Configuration Result: Configuration in progress, please wait..."
-    Start-Sleep -Seconds 30  # Wait for a few seconds before retrying
 	
     if ($configResult -eq "0true") {
         Write-Host "Configuration Result: Configuration finished."

--- a/Samples/PowerShell/SAM.AppInsightAutomation/CreateAppInsightForIIS.ps1
+++ b/Samples/PowerShell/SAM.AppInsightAutomation/CreateAppInsightForIIS.ps1
@@ -49,15 +49,15 @@ $shouldConfigureIISServer = $true
 if ($shouldConfigureIISServer) {
 	Write-Host "Scheduling IIS configuration for Application ID '$applicationId'."
 
-$maxRetries = 5
+$maxRetries = 10
 $retryCount = 0
 $executionKey = (Invoke-SwisVerb $swis "Orion.APM.IIS.Application" "ScheduleConfiguration" @($applicationId, $credentialSetId)).InnerText
 
 while ($retryCount -lt $maxRetries) {
+    Start-Sleep -Seconds 15  # Wait for a few seconds before retrying
 	$configResult = (Invoke-SwisVerb $swis "Orion.APM.IIS.Application" "GetConfigurationResult" @($executionKey)).InnerText
 	
 	Write-Host "Configuration Result: Configuration in progress, please wait..."
-    Start-Sleep -Seconds 30  # Wait for a few seconds before retrying
 	
     if ($configResult -eq "0true") {
         Write-Host "Configuration Result: Configuration finished."

--- a/Samples/PowerShell/SAM.AppInsightAutomation/CreateAppInsightForIIS.ps1
+++ b/Samples/PowerShell/SAM.AppInsightAutomation/CreateAppInsightForIIS.ps1
@@ -41,3 +41,35 @@ if ($applicationId -eq -1) {
 else {
 	Write-Host "Application created with ID '$applicationId'."
 }
+
+# Default condition for configuring IIS Server
+$shouldConfigureIISServer = $true
+
+# Configure IIS if the condition is true
+if ($shouldConfigureIISServer) {
+	Write-Host "Scheduling IIS configuration for Application ID '$applicationId'."
+
+$maxRetries = 5
+$retryCount = 0
+$executionKey = (Invoke-SwisVerb $swis "Orion.APM.IIS.Application" "ScheduleConfiguration" @($applicationId, $credentialSetId)).InnerText
+
+while ($retryCount -lt $maxRetries) {
+	$configResult = (Invoke-SwisVerb $swis "Orion.APM.IIS.Application" "GetConfigurationResult" @($executionKey)).InnerText
+	
+	Write-Host "Configuration Result: Configuration in progress, please wait..."
+    Start-Sleep -Seconds 30  # Wait for a few seconds before retrying
+	
+    if ($configResult -eq "0true") {
+        Write-Host "Configuration Result: Configuration finished."
+        break
+    } else {
+        Write-Host "Configuration not yet complete..."
+        $retryCount++
+    }
+  }
+  
+  if ($configResult -eq "false") {
+        Write-Host "Configuration Result: Configuration failed."
+        break
+    }
+}


### PR DESCRIPTION
This pull request addresses an issue with a missing configuration part for IIS/Exchange which is mentioned in KB
https://documentation.solarwinds.com/en/success_center/sam/content/sam-appinsight-automate-configuration.htm

script names in KB are outdated(will be updated from exch_create to CreateAppInsightForExchange.ps1 from iis_create to CreateAppInsightForIIS.ps1)

(internal tracking ID: OO-35501)