### PR TITLE
Update log4net to 3.3.0

### DIFF
--- a/Src/Directory.Packages.props
+++ b/Src/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="DockPanelSuite.ThemeVS2015" Version="3.0.6" />
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="jacobslusser.ScintillaNET" Version="3.6.3" />
-    <PackageVersion Include="log4net" Version="2.0.15" />
+    <PackageVersion Include="log4net" Version="3.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />


### PR DESCRIPTION
Upgraded the project to use log4net 3.3.0 to resolve the NU1902 vulnerability warning caused by the outdated 2.0.15 version, allowing the OrionSDK build to restore and compile successfully.