### PR TITLE
fix(SwqlStudio): quote URL and fix bash POST command in Copy Query As / Curl

### DIFF
--- a/Src/SwqlStudio/Utils/CommandLineGenerator.cs
+++ b/Src/SwqlStudio/Utils/CommandLineGenerator.cs
@@ -65,15 +65,21 @@ namespace SwqlStudio.Utils
 
         private static string GetQueryForCurlBashInternal(string query, ConnectionInfo connection, PropertyBag parameters, int port)
         {
-            var url = GetUrlForQuery(query, connection, port);
             Func<string, string> q = QuoteForBash;
             if (!parameters.Any())
             {
-                return $"curl -k -u {QuoteForBash(CredentialsPlaceholder)} {QuoteForBash(url)}";
+                var url = GetUrlForQuery(query, connection, port);
+                return $"curl -k -u {q(CredentialsPlaceholder)} {q(url)}";
             }
             else
             {
-                return GetQueryForCurlCmdInternal(query, connection, parameters, port);
+                var escapedQuery = CollapseWhitespace(query);
+                var postUrl = GetUrlForQuery(null, connection, port);
+                var parametersSerialized = string.Join(
+                    ",",
+                    parameters.Select(x => string.Format("\"{0}\" : \"{1}\"", x.Key, x.Value.ToString())));
+                var postData = $"{{ \"query\": \"{escapedQuery}\", \"parameters\": {{{parametersSerialized}}}}}";
+                return $"curl -X POST -d {q(postData)} {q(postUrl)} --insecure -u {q(CredentialsPlaceholder)} --header {q("Content-Type:application/json")}";
             }
         }
 
@@ -144,9 +150,6 @@ namespace SwqlStudio.Utils
 
         private static string QuoteForBash(string arg)
         {
-            if (arg.IndexOf('\'') == -1)
-                return arg;
-
             var quoted = new StringBuilder("'");
 
             foreach (char c in arg)


### PR DESCRIPTION
## Summary

Fixes #334

Two bugs in the **Edit → Copy Query As → Curl (bash)** output in SWQL Studio.

### Bug 1 — URL not quoted (affects all bash/PowerShell users)

`QuoteForBash()` only wrapped an argument in single quotes when it already contained a single quote. URLs with `?`, `(`, `)` are special to bash and PowerShell, so the unquoted URL caused parse errors:

```
# Before — unquoted URL breaks PowerShell and bash when query has GETUTCDATE() or WHERE (...)
curl -k -u 'YOUR_USERNAME:YOUR_PASSWORD' https://host:17774/.../Query?query=...GETUTCDATE()...

# After — URL safely wrapped in single quotes
curl -k -u 'YOUR_USERNAME:YOUR_PASSWORD' 'https://host:17774/.../Query?query=...GETUTCDATE()...'
```

**Fix:** Remove the early-return in `QuoteForBash()`; always wrap in single quotes and escape embedded single quotes as `'\''`.

### Bug 2 — Bash variant with parameters delegated to cmd variant

When the query used parameters, `GetQueryForCurlBashInternal()` called `GetQueryForCurlCmdInternal()` directly. This produced a cmd-style command (double-quoted args, `curl.exe`) that is invalid in bash, and caused the doubled `curl -k -u ... curl -k -u ...` prefix visible in the issue.

**Fix:** Build the bash POST command directly in `GetQueryForCurlBashInternal()` using `QuoteForBash()` for all arguments.

## Test plan

- [ ] Open SWQL Studio, run a query containing `GETUTCDATE()` or a `WHERE (...)` clause
- [ ] Edit → Copy Query As → Curl (bash) — paste into bash/PowerShell, confirm no parse errors
- [ ] Repeat with a parameterized query — confirm the bash POST command is well-formed