### PR TITLE
Added valid certificate fingerprint for log4net v3

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -18,6 +18,7 @@
     <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
       <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
     </repository>
   </trustedSigners>
 </configuration>


### PR DESCRIPTION
Log4net 3.3.0 is signed with a different certificate than 2.0.15 was. Adding the certificate hash to trusted certs.