### PR TITLE
Fix FontSizeToolbar disposing the shared default font

### DIFF
--- a/Src/SwqlStudio/ObjectExplorer/FontSizeToolbar.cs
+++ b/Src/SwqlStudio/ObjectExplorer/FontSizeToolbar.cs
@@ -22,6 +22,9 @@ namespace SwqlStudio.ObjectExplorer
         private float _minFontSize;
         private float _maxFontSize;
 
+        // Only fonts created here may be disposed; Target.Font may be a shared ambient font (see DpiHelper.DefaultFont).
+        private Font _ownedFont;
+
         private readonly float _step;
 
         public FontSizeToolbar(float scaleFactor)
@@ -82,9 +85,7 @@ namespace SwqlStudio.ObjectExplorer
             if (Math.Abs(newSize - _target.Font.Size) < 0.01f)
                 return;
 
-            var oldFont = Target.Font;
-            Target.Font = new Font(oldFont.FontFamily, newSize, oldFont.Style, oldFont.Unit);
-            oldFont.Dispose();
+            ApplyFontSize(newSize);
 
             UpdateResetButton();
 
@@ -101,11 +102,31 @@ namespace SwqlStudio.ObjectExplorer
             if (Target == null || !_initialFontSize.HasValue)
                 return;
 
-            var oldFont = Target.Font;
-            Target.Font = new Font(oldFont.FontFamily, _initialFontSize.Value, oldFont.Style, oldFont.Unit);
-            oldFont.Dispose();
+            ApplyFontSize(_initialFontSize.Value);
 
             UpdateResetButton();
+        }
+
+        private void ApplyFontSize(float size)
+        {
+            var currentFont = Target.Font;
+            var previouslyOwnedFont = _ownedFont;
+
+            _ownedFont = new Font(currentFont.FontFamily, size, currentFont.Style, currentFont.Unit);
+            Target.Font = _ownedFont;
+
+            previouslyOwnedFont?.Dispose();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _ownedFont?.Dispose();
+                _ownedFont = null;
+            }
+
+            base.Dispose(disposing);
         }
 
         private void UpdateResetButton()

--- a/Src/SwqlStudio/ObjectExplorer/FontSizeToolbar.cs
+++ b/Src/SwqlStudio/ObjectExplorer/FontSizeToolbar.cs
@@ -23,6 +23,7 @@ namespace SwqlStudio.ObjectExplorer
         private float _maxFontSize;
 
         // Only fonts created here may be disposed; Target.Font may be a shared ambient font (see DpiHelper.DefaultFont).
+        private Font _initialFont;
         private Font _ownedFont;
 
         private readonly float _step;
@@ -67,7 +68,17 @@ namespace SwqlStudio.ObjectExplorer
 
         public Control Target
         {
-            get => _target; set => _target = value;
+            get => _target;
+            set
+            {
+                if (ReferenceEquals(_target, value))
+                    return;
+
+                ReleaseOwnedFont();
+                _target = value;
+                _initialFontSize = null;
+                UpdateResetButton();
+            }
         }
 
         private void ChangeFont(int delta)
@@ -110,10 +121,21 @@ namespace SwqlStudio.ObjectExplorer
         private void ApplyFontSize(float size)
         {
             var currentFont = Target.Font;
-            var previouslyOwnedFont = _ownedFont;
 
-            _ownedFont = new Font(currentFont.FontFamily, size, currentFont.Style, currentFont.Unit);
-            Target.Font = _ownedFont;
+            if (_ownedFont != null && !ReferenceEquals(currentFont, _ownedFont))
+            {
+                _ownedFont.Dispose();
+                _ownedFont = null;
+            }
+
+            if (_ownedFont == null)
+                _initialFont = currentFont;
+
+            var previouslyOwnedFont = _ownedFont;
+            var newFont = new Font(currentFont.FontFamily, size, currentFont.Style, currentFont.Unit);
+
+            Target.Font = newFont;
+            _ownedFont = newFont;
 
             previouslyOwnedFont?.Dispose();
         }
@@ -121,12 +143,22 @@ namespace SwqlStudio.ObjectExplorer
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-            {
-                _ownedFont?.Dispose();
-                _ownedFont = null;
-            }
+                ReleaseOwnedFont();
 
             base.Dispose(disposing);
+        }
+
+        private void ReleaseOwnedFont()
+        {
+            if (_ownedFont == null)
+                return;
+
+            if (_target != null && !_target.IsDisposed && ReferenceEquals(_target.Font, _ownedFont))
+                _target.Font = _initialFont;
+
+            _ownedFont.Dispose();
+            _ownedFont = null;
+            _initialFont = null;
         }
 
         private void UpdateResetButton()

--- a/Src/Test/SwqlStudio.Tests/FontSizeToolbarTests.cs
+++ b/Src/Test/SwqlStudio.Tests/FontSizeToolbarTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using SwqlStudio.ObjectExplorer;
+using Xunit;
+
+namespace SwqlStudio.Tests
+{
+    public class FontSizeToolbarTests
+    {
+        [Fact]
+        public void IncreasingFontSizeDoesNotDisposeInitialFont()
+        {
+            using (var initialFont = new Font("Microsoft Sans Serif", 8.25f))
+            using (var target = new Label { Font = initialFont })
+            using (var toolbar = CreateToolbar(target))
+            {
+                ClickButton(toolbar, "Increase font");
+
+                Assert.NotSame(initialFont, target.Font);
+                AssertFontIsUsable(initialFont);
+            }
+        }
+
+        [Fact]
+        public void ChangingFontSizeDisposesPreviouslyOwnedFont()
+        {
+            using (var initialFont = new Font("Microsoft Sans Serif", 8.25f))
+            using (var target = new Label { Font = initialFont })
+            using (var toolbar = CreateToolbar(target))
+            {
+                ClickButton(toolbar, "Increase font");
+                Font firstOwnedFont = target.Font;
+
+                ClickButton(toolbar, "Increase font");
+
+                AssertFontIsDisposed(firstOwnedFont);
+                AssertFontIsUsable(target.Font);
+            }
+        }
+
+        [Fact]
+        public void ResettingFontSizeDisposesOwnedFontAndPreservesInitialFont()
+        {
+            using (var initialFont = new Font("Microsoft Sans Serif", 8.25f))
+            using (var target = new Label { Font = initialFont })
+            using (var toolbar = CreateToolbar(target))
+            {
+                ClickButton(toolbar, "Increase font");
+                Font increasedFont = target.Font;
+
+                ClickButton(toolbar, "Reset font");
+
+                Assert.Equal(initialFont.Size, target.Font.Size);
+                Assert.NotSame(initialFont, target.Font);
+                AssertFontIsDisposed(increasedFont);
+                AssertFontIsUsable(initialFont);
+                AssertFontIsUsable(target.Font);
+            }
+        }
+
+        [Fact]
+        public void ChangingTargetRestoresPreviousTargetsInitialFont()
+        {
+            using (var firstInitialFont = new Font("Microsoft Sans Serif", 8.25f))
+            using (var secondInitialFont = new Font("Microsoft Sans Serif", 9f))
+            using (var firstTarget = new Label { Font = firstInitialFont })
+            using (var secondTarget = new Label { Font = secondInitialFont })
+            using (var toolbar = CreateToolbar(firstTarget))
+            {
+                ClickButton(toolbar, "Increase font");
+                Font firstOwnedFont = firstTarget.Font;
+
+                toolbar.Target = secondTarget;
+
+                Assert.Same(firstInitialFont, firstTarget.Font);
+                AssertFontIsUsable(firstTarget.Font);
+                AssertFontIsDisposed(firstOwnedFont);
+            }
+        }
+
+        [Fact]
+        public void DisposingToolbarRestoresTargetsInitialFont()
+        {
+            using (var initialFont = new Font("Microsoft Sans Serif", 8.25f))
+            using (var target = new Label { Font = initialFont })
+            {
+                var toolbar = CreateToolbar(target);
+                ClickButton(toolbar, "Increase font");
+                Font ownedFont = target.Font;
+
+                toolbar.Dispose();
+
+                Assert.Same(initialFont, target.Font);
+                AssertFontIsUsable(target.Font);
+                AssertFontIsDisposed(ownedFont);
+            }
+        }
+
+        private static FontSizeToolbar CreateToolbar(Control target) =>
+            new FontSizeToolbar(1f) { Target = target };
+
+        private static void ClickButton(FontSizeToolbar toolbar, string tooltip)
+        {
+            ToolStrip strip = toolbar.Controls.OfType<ToolStrip>().Single();
+            ToolStripButton button = strip.Items
+                .OfType<ToolStripButton>()
+                .Single(item => item.ToolTipText == tooltip);
+
+            button.PerformClick();
+        }
+
+        private static void AssertFontIsUsable(Font font)
+        {
+            IntPtr handle = font.ToHfont();
+            Assert.NotEqual(IntPtr.Zero, handle);
+            DeleteObject(handle);
+        }
+
+        private static void AssertFontIsDisposed(Font font) =>
+            Assert.Throws<ArgumentException>(() => font.ToHfont());
+
+        [DllImport("gdi32.dll")]
+        private static extern bool DeleteObject(IntPtr handle);
+    }
+}


### PR DESCRIPTION
FontSizeToolbar disposed the target control's shared default font, causing an ArgumentException when the font was used afterwards. The toolbar now only disposes fonts it created itself and restores the original font on dispose.

Adds unit tests covering font ownership, resize behavior and disposal.