### PR TITLE
Detect dropped SWIS connections and reconnect automatically in SWQL Studio

### DIFF
--- a/Src/SwqlStudio/ConnectionInfo.cs
+++ b/Src/SwqlStudio/ConnectionInfo.cs
@@ -5,11 +5,14 @@ using System.IO;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Security;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
 using SolarWinds.InformationService.Contract2;
 using SolarWinds.InformationService.Contract2.PubSub;
 using SolarWinds.InformationService.InformationServiceClient;
+using SolarWinds.Logging;
 using SwqlStudio.Properties;
 using SwqlStudio.Subscriptions;
 
@@ -17,6 +20,11 @@ namespace SwqlStudio
 {
     public class ConnectionInfo : IDisposable
     {
+        private static readonly Log log = new Log();
+
+        private static readonly TimeSpan KeepAliveCheckInterval = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan ReconnectRetryInterval = TimeSpan.FromSeconds(10);
+
         public string ServerType { get; set; }
         private string _server;
         private string _username;
@@ -24,19 +32,34 @@ namespace SwqlStudio
 
         private InfoServiceProxy _proxy;
         private readonly InfoServiceBase _infoServiceType;
+        private CancellationTokenSource _keepAliveCts;
+        private bool _isClosed;
+
+        // Bumped whenever the proxy is replaced or closed, so a slow reconnect can detect it lost the race.
+        private int _connectionGeneration;
+
+        private readonly SynchronizationContext _syncContext;
+        private readonly object _proxyLock = new object();
 
         public event EventHandler<EventArgs> ConnectionClosed;
         public event EventHandler<EventArgs> ConnectionClosing;
+        public event EventHandler<EventArgs> ConnectionRestored;
 
         public ConnectionInfo(string server, string username, string password, string serverType)
+            : this(server, username, password, serverType, InfoServiceFactory.Create(serverType, username, password))
+        {
+        }
+
+        internal ConnectionInfo(string server, string username, string password, string serverType, InfoServiceBase infoServiceType)
         {
             ServerType = serverType;
             _server = server;
             _username = username;
             _password = password;
 
-            _infoServiceType = InfoServiceFactory.Create(serverType, username, password);
+            _infoServiceType = infoServiceType;
             QueryParameters = new PropertyBag();
+            _syncContext = SynchronizationContext.Current;
         }
 
         public Binding Binding
@@ -127,24 +150,36 @@ namespace SwqlStudio
 
         public void Connect()
         {
-            if (_proxy == null || (_proxy != null && (_proxy.Channel.State == CommunicationState.Closed || _proxy.Channel.State == CommunicationState.Faulted)))
+            lock (_proxyLock)
             {
-                if (_proxy != null)
-                    _proxy.Dispose();
+                if (_proxy == null || _proxy.Channel.State == CommunicationState.Closed || _proxy.Channel.State == CommunicationState.Faulted)
+                {
+                    // Clear it first; if OpenProxy() throws, the next attempt must not inspect the disposed one.
+                    var stale = _proxy;
+                    _proxy = null;
+                    DisposeQuietly(stale);
 
-                _proxy = _infoServiceType.CreateProxy(_server);
-                _proxy.OperationTimeout = TimeSpan.FromMinutes(Settings.Default.OperationTimeout);
-                _proxy.ChannelFactory.Endpoint.Behaviors.Add(new LogHeaderReaderBehavior());
-                _proxy.Open();
+                    _proxy = OpenProxy();
+                    _isClosed = false;
+                    _connectionGeneration++;
+                    StartKeepAlive();
+                }
+
+                DisposeQuietly(Connection);
+                Connection = new InformationServiceConnection((IInformationService)_proxy);
+                Connection.Open();
             }
-
-            Connection = new InformationServiceConnection((IInformationService)_proxy);
-            Connection.Open();
         }
 
-        public bool IsConnected
+        public virtual bool IsConnected
         {
-            get { return _proxy != null && _proxy.ClientChannel.State == CommunicationState.Opened; }
+            get
+            {
+                lock (_proxyLock)
+                {
+                    return _proxy != null && _proxy.ClientChannel.State == CommunicationState.Opened;
+                }
+            }
         }
 
         internal NotificationDeliveryServiceProxy CreateActiveListenerProxy(INotificationSubscriber listener)
@@ -153,6 +188,217 @@ namespace SwqlStudio
                 throw new InvalidOperationException("This connection type doesn't support active subscriptions");
 
             return _infoServiceType.CreateNotificationDeliveryServiceProxy(_server, listener);
+        }
+
+        private void StartKeepAlive()
+        {
+            StopKeepAlive();
+
+            var cts = new CancellationTokenSource();
+            _keepAliveCts = cts;
+
+            // Capture the token before scheduling; a concurrent Close() can null the field before the task starts.
+            CancellationToken token = cts.Token;
+            Task.Run(() => KeepAliveMonitor(token));
+        }
+
+        private void StopKeepAlive()
+        {
+            if (_keepAliveCts != null)
+            {
+                _keepAliveCts.Cancel();
+                _keepAliveCts.Dispose();
+                _keepAliveCts = null;
+            }
+        }
+
+        private async Task KeepAliveMonitor(CancellationToken ct)
+        {
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    await Task.Delay(KeepAliveCheckInterval, ct);
+
+                    if (ct.IsCancellationRequested)
+                        break;
+
+                    if (!IsConnected)
+                    {
+                        OnConnectionLost();
+
+                        while (!ct.IsCancellationRequested && !IsConnected)
+                        {
+                            int? committedGeneration = await TryReconnectAsync(ct);
+
+                            if (committedGeneration.HasValue)
+                            {
+                                // Validated inside the state transition, so Close() cannot slip in behind the check.
+                                RaiseConnectionRestored(committedGeneration.Value);
+
+                                break;
+                            }
+
+                            await Task.Delay(ReconnectRetryInterval, ct);
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when closing
+            }
+            catch (ObjectDisposedException)
+            {
+                // The token source was disposed by Close() while we were waiting on it.
+            }
+            catch (Exception ex)
+            {
+                // This runs detached, so an escaping exception would otherwise go unobserved.
+                log.Error($"Keep-alive monitor for {_server} stopped unexpectedly", ex);
+            }
+        }
+
+        protected internal virtual void OnConnectionLost()
+        {
+            var handler = ConnectionClosed;
+            if (handler != null)
+                Dispatch(() => handler.Invoke(this, EventArgs.Empty));
+        }
+
+        protected internal virtual void OnConnectionRestored()
+        {
+            int generation;
+            lock (_proxyLock)
+            {
+                generation = _connectionGeneration;
+            }
+
+            RaiseConnectionRestored(generation);
+        }
+
+        private bool IsGenerationCurrent(int generation)
+        {
+            lock (_proxyLock)
+            {
+                return !_isClosed && _connectionGeneration == generation;
+            }
+        }
+
+        /// <summary>Runs the callback on the context this connection was created on, when there is one.</summary>
+        private void Dispatch(Action action)
+        {
+            if (_syncContext != null)
+                _syncContext.Post(_ => action(), null);
+            else
+                action();
+        }
+
+        /// <param name="expectedGeneration">Generation the caller committed; a newer one means it lost the race.</param>
+        private void RaiseConnectionRestored(int expectedGeneration)
+        {
+            if (!IsGenerationCurrent(expectedGeneration))
+                return;
+
+            var handler = ConnectionRestored;
+            if (handler != null)
+                Dispatch(() => handler.Invoke(this, EventArgs.Empty));
+        }
+
+        /// <summary>Returns the generation it committed, or null when the attempt failed or lost the race.</summary>
+        private async Task<int?> TryReconnectAsync(CancellationToken ct)
+        {
+            InfoServiceProxy newProxy = null;
+            InformationServiceConnection newConnection = null;
+
+            try
+            {
+                if (ct.IsCancellationRequested)
+                    return null;
+
+                int generationAtStart;
+                lock (_proxyLock)
+                {
+                    if (_isClosed)
+                        return null;
+
+                    generationAtStart = _connectionGeneration;
+                }
+
+                // Build the whole replacement off to the side so a partial failure cannot corrupt live state.
+                newProxy = OpenProxy();
+
+                newConnection = new InformationServiceConnection((IInformationService)newProxy);
+                newConnection.Open();
+
+                lock (_proxyLock)
+                {
+                    // Close() or another reconnect may have won while we were opening; discard our replacement.
+                    if (_isClosed || ct.IsCancellationRequested || _connectionGeneration != generationAtStart)
+                        return null;
+
+                    var oldProxy = _proxy;
+                    var oldConnection = Connection;
+
+                    _proxy = newProxy;
+                    Connection = newConnection;
+                    _connectionGeneration++;
+
+                    newProxy = null;
+                    newConnection = null;
+
+                    DisposeQuietly(oldConnection);
+                    DisposeQuietly(oldProxy);
+
+                    return _connectionGeneration;
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Error($"Reconnect attempt to {_server} failed", ex);
+                return null;
+            }
+            finally
+            {
+                // Non-null only when the attempt failed or lost the race.
+                DisposeQuietly(newConnection);
+                DisposeQuietly(newProxy);
+            }
+        }
+
+        private InfoServiceProxy OpenProxy()
+        {
+            var proxy = _infoServiceType.CreateProxy(_server);
+
+            try
+            {
+                proxy.OperationTimeout = TimeSpan.FromMinutes(Settings.Default.OperationTimeout);
+                proxy.ChannelFactory.Endpoint.Behaviors.Add(new LogHeaderReaderBehavior());
+                proxy.Open();
+            }
+            catch
+            {
+                // The caller never received the proxy, so it cannot dispose it for us.
+                DisposeQuietly(proxy);
+                throw;
+            }
+
+            return proxy;
+        }
+
+        private static void DisposeQuietly(IDisposable disposable)
+        {
+            if (disposable == null)
+                return;
+
+            try
+            {
+                disposable.Dispose();
+            }
+            catch (Exception ex)
+            {
+                log.Warn("Failed to dispose a replaced connection resource.", ex);
+            }
         }
 
         private void EnsureConnection()
@@ -352,16 +598,25 @@ namespace SwqlStudio
 
         public void Close()
         {
-            if (_proxy != null)
+            lock (_proxyLock)
             {
-                var listeners = ConnectionClosing;
-                listeners?.Invoke(this, EventArgs.Empty);
+                // Set before anything else so a reconnect already in flight refuses to commit.
+                _isClosed = true;
+                _connectionGeneration++;
+                StopKeepAlive();
 
-                _proxy.Dispose();
+                if (_proxy == null)
+                    return;
+
+                ConnectionClosing?.Invoke(this, EventArgs.Empty);
+
+                DisposeQuietly(Connection);
+                Connection = null;
+
+                DisposeQuietly(_proxy);
                 _proxy = null;
 
-                listeners = ConnectionClosed;
-                listeners?.Invoke(this, EventArgs.Empty);
+                ConnectionClosed?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/Src/SwqlStudio/ConnectionsManager.cs
+++ b/Src/SwqlStudio/ConnectionsManager.cs
@@ -47,7 +47,7 @@ namespace SwqlStudio
                 return found;
 
             info.Connect();
-            info.ConnectionClosed += (sender, args) => serverList.Remove(info);
+            info.ConnectionClosing += (sender, args) => serverList.Remove(info);
             serverList.Add(info);
             return info;
         }

--- a/Src/SwqlStudio/MainForm.cs
+++ b/Src/SwqlStudio/MainForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Drawing;
 using System.Linq;
 using System.ServiceModel;
 using System.Windows.Forms;
@@ -22,6 +23,9 @@ namespace SwqlStudio
         private readonly BindingList<ConnectionInfo> connectionsDataSource = new BindingList<ConnectionInfo>();
         private ConnectionsManager connectionsManager;
         private QueryTab lastActiveTab;
+        private readonly string executeDefaultToolTip;
+        private readonly Color executeDefaultBackColor;
+        private readonly Color executeDefaultForeColor;
 
         public PropertyBag QueryParameters
         {
@@ -41,6 +45,10 @@ namespace SwqlStudio
         {
             DpiHelper.FixFont(this);
             InitializeComponent();
+
+            executeDefaultToolTip = executeToolButton.ToolTipText;
+            executeDefaultBackColor = executeToolButton.BackColor;
+            executeDefaultForeColor = menuQueryExecute.ForeColor;
 
             InitializeDockPanel();
             SetEntityGroupingMode((EntityGroupingMode)Enum.Parse(typeof(EntityGroupingMode),
@@ -80,6 +88,7 @@ namespace SwqlStudio
             if (activeConnectionTab != null)
             {
                 SelectedConnection = activeConnectionTab.ConnectionInfo;
+                UpdateExecuteVisual(activeConnectionTab.ConnectionInfo);
             }
 
 
@@ -107,18 +116,52 @@ namespace SwqlStudio
             filesDock.AddServer(provider, addedConnection);
             SelectedConnection = addedConnection;
 
+            HookConnectionVisuals(addedConnection);
+
             if (connectionsDataSource.Count == 1)
                 filesDock.ReplaceConnection(null, addedConnection);
         }
 
         private void ServerListOnConnectionRemoved(object sender, ConnectionsEventArgs e)
         {
+            UnhookConnectionVisuals(e.Connection);
             connectionsDataSource.Remove(e.Connection);
 
             if (connectionsDataSource.Any())
                 SelectedConnection = connectionsDataSource.First();
 
             filesDock.CloseServer(e.Connection, SelectedConnection);
+        }
+
+        private void HookConnectionVisuals(ConnectionInfo connection)
+        {
+            connection.ConnectionClosed += ConnectionStateChanged;
+            connection.ConnectionRestored += ConnectionStateChanged;
+        }
+
+        private void UnhookConnectionVisuals(ConnectionInfo connection)
+        {
+            connection.ConnectionClosed -= ConnectionStateChanged;
+            connection.ConnectionRestored -= ConnectionStateChanged;
+        }
+
+        private void ConnectionStateChanged(object sender, EventArgs e)
+        {
+            var connection = sender as ConnectionInfo;
+            if (connection != SelectedConnection)
+                return;
+
+            // A stale event can arrive after the connection closed, so trust the state, not the event.
+            UpdateExecuteVisual(connection);
+        }
+
+        private void UpdateExecuteVisual(ConnectionInfo connection)
+        {
+            bool disconnected = connection != null && !connection.IsConnected;
+
+            executeToolButton.BackColor = disconnected ? Color.Gold : executeDefaultBackColor;
+            executeToolButton.ToolTipText = disconnected ? "Execute query (disconnected — retrying)" : executeDefaultToolTip;
+            menuQueryExecute.ForeColor = disconnected ? Color.DarkGoldenrod : executeDefaultForeColor;
         }
 
         private void startTimer_Tick(object sender, EventArgs e)

--- a/Src/SwqlStudio/QueryStatusBar.cs
+++ b/Src/SwqlStudio/QueryStatusBar.cs
@@ -8,11 +8,17 @@ namespace SwqlStudio
     {
         private const string NotAvailable = "N/A";
 
+        internal const string Connected = "Connected";
+        internal const string Disconnected = "Disconnected";
+        internal const string Disconnecting = "Disconnecting...";
+
         private readonly ToolStripStatusLabel _connectionLabel;
         private readonly ToolStripStatusLabel _serverLabel;
         private readonly ToolStripStatusLabel _userLabel;
         private readonly ToolStripStatusLabel _queryTimeLabel;
         private readonly ToolStripStatusLabel _rowCountLabel;
+
+        private ConnectionInfo _connection;
 
         public QueryStatusBar()
         {
@@ -51,20 +57,30 @@ namespace SwqlStudio
         {
             Items.AddRange(AllLabels);
 
+            _connection = connection;
+            ShowConnectionState();
+
             if (connection != null)
             {
-                _connectionLabel.Text = "Connected";
                 _serverLabel.Text = string.Format("Server: {0}", connection.Server);
                 _userLabel.Text = string.Format("User: {0}", connection.UserName);
             }
             else
             {
-                _connectionLabel.Text = NotAvailable;
                 _serverLabel.Text = NotAvailable;
                 _userLabel.Text = NotAvailable;
             }
 
             UpdateValues(0, TimeSpan.Zero);
+        }
+
+        /// <summary>Shows the connection state, which is the status bar's idle text.</summary>
+        public void ShowConnectionState()
+        {
+            if (_connection == null)
+                _connectionLabel.Text = NotAvailable;
+            else
+                _connectionLabel.Text = _connection.IsConnected ? Connected : Disconnected;
         }
 
         public void UpdateValues(int rowCount, TimeSpan queryTime, long? totalRows = null)
@@ -80,5 +96,7 @@ namespace SwqlStudio
         {
             _connectionLabel.Text = text;
         }
+
+        internal string ConnectionStatus => _connectionLabel.Text;
     }
 }

--- a/Src/SwqlStudio/QueryTab.cs
+++ b/Src/SwqlStudio/QueryTab.cs
@@ -36,11 +36,38 @@ namespace SwqlStudio
         {
             set
             {
+                DetachConnectionEvents(base.ConnectionInfo);
+
                 base.ConnectionInfo = value;
+
+                AttachConnectionEvents(base.ConnectionInfo);
+
                 SetMetadataProvider();
                 queryStatusBar1.Initialize(base.ConnectionInfo);
             }
         }
+
+        private void AttachConnectionEvents(ConnectionInfo connection)
+        {
+            if (connection == null)
+                return;
+
+            connection.ConnectionClosed += _connectionInfo_ConnectionClosed;
+            connection.ConnectionClosing += _connectionInfo_ConnectionClosing;
+            connection.ConnectionRestored += _connectionInfo_ConnectionRestored;
+        }
+
+        private void DetachConnectionEvents(ConnectionInfo connection)
+        {
+            if (connection == null)
+                return;
+
+            connection.ConnectionClosed -= _connectionInfo_ConnectionClosed;
+            connection.ConnectionClosing -= _connectionInfo_ConnectionClosing;
+            connection.ConnectionRestored -= _connectionInfo_ConnectionRestored;
+        }
+
+        internal string CurrentStatus => queryStatusBar1?.ConnectionStatus;
 
         [Flags]
         private enum Tabs
@@ -100,6 +127,7 @@ namespace SwqlStudio
                 nullFont.Dispose();
                 nullFont = null;
             }
+            DetachConnectionEvents(ConnectionInfo);
             Unsubscribe();
         }
 
@@ -422,7 +450,7 @@ namespace SwqlStudio
                     }
 
                     queryStatusBar1.UpdateValues(arg.Results.Rows.Count, arg.QueryTime, (long?)arg.Results.ExtendedProperties["TotalRows"]);
-                    queryStatusBar1.UpdateStatusLabel("Ready");
+                    queryStatusBar1.ShowConnectionState();
 
                     RawXmlTabVisible = false;
                     ResultsTabVisible = true;
@@ -434,7 +462,7 @@ namespace SwqlStudio
                     ResultsTabVisible = false;
 
                     queryStatusBar1.UpdateValues(0, arg.QueryTime);
-                    queryStatusBar1.UpdateStatusLabel("Ready");
+                    queryStatusBar1.ShowConnectionState();
                 }
 
                 if (arg.Errors != null)
@@ -879,6 +907,49 @@ namespace SwqlStudio
         public void HideFindReplaceDialog()
         {
             findReplaceDialog.Window.Hide();
+        }
+
+        private void _connectionInfo_ConnectionClosed(object sender, EventArgs e)
+        {
+            ShowConnectionStatus(null);
+        }
+
+        private void _connectionInfo_ConnectionClosing(object sender, EventArgs e)
+        {
+            ShowConnectionStatus(QueryStatusBar.Disconnecting);
+        }
+
+        private void _connectionInfo_ConnectionRestored(object sender, EventArgs e)
+        {
+            ShowConnectionStatus(null);
+        }
+
+        /// <param name="status">Literal to show, or null to re-read the live connection state.</param>
+        private void ShowConnectionStatus(string status)
+        {
+            // The connection raises events from a background thread, so the tab may be torn down mid-flight.
+            if (IsDisposed || Disposing)
+                return;
+
+            if (InvokeRequired)
+            {
+                try
+                {
+                    BeginInvoke(new Action<string>(ShowConnectionStatus), status);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Tab was disposed between the check above and the marshalling call.
+                }
+
+                return;
+            }
+
+            // A stale event can arrive after the connection closed, so trust the state, not the event.
+            if (status == null)
+                queryStatusBar1?.ShowConnectionState();
+            else
+                queryStatusBar1?.UpdateStatusLabel(status);
         }
     }
 }

--- a/Src/Test/SwqlStudio.Tests/ConnectionInfoTests.cs
+++ b/Src/Test/SwqlStudio.Tests/ConnectionInfoTests.cs
@@ -1,0 +1,251 @@
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Threading;
+using FluentAssertions;
+using SolarWinds.InformationService.Contract2;
+using SolarWinds.InformationService.InformationServiceClient;
+using SwqlStudio;
+using Xunit;
+
+namespace SwqlStudio.Tests
+{
+    public class ConnectionInfoTests
+    {
+        [Fact]
+        public void DoWithExceptionTranslation_Retries_On_CommunicationObjectFaulted()
+        {
+            int tries = 0;
+            int result = ConnectionInfo.DoWithExceptionTranslation(() =>
+            {
+                if (tries++ == 0)
+                    throw new CommunicationObjectFaultedException("faulted");
+                return 42;
+            });
+
+            result.Should().Be(42);
+            tries.Should().Be(2);
+        }
+
+        [Fact]
+        public void DoWithExceptionTranslation_Wraps_FaultException()
+        {
+            Action act = () => ConnectionInfo.DoWithExceptionTranslation<int>(() =>
+            {
+                throw new FaultException("boom");
+            });
+
+            act.Should().Throw<ApplicationException>()
+                .WithMessage("boom");
+        }
+
+        [Fact]
+        public void IsConnected_IsFalse_When_NoProxy()
+        {
+            var info = new TestConnectionInfo();
+            info.IsConnected.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Copy_Clones_Credentials_And_Type()
+        {
+            var info = new TestConnectionInfo("server1", "user", "pass", "Orion (v3)")
+            {
+                QueryParameters = new PropertyBag { { "k", "v" } }
+            };
+
+            var clone = info.Copy();
+
+            clone.Server.Should().Be("server1");
+            clone.UserName.Should().Be("user");
+            clone.Password.Should().Be("pass");
+            clone.ServerType.Should().Be("Orion (v3)");
+            clone.QueryParameters.Should().ContainKey("k");
+        }
+
+        [Fact]
+        public void OnConnectionRestored_IsSuppressed_AfterClose()
+        {
+            // Built without a SynchronizationContext so the event fires synchronously and the assertion is deterministic.
+            var info = CreateWithoutSyncContext();
+            bool restoredRaised = false;
+            info.ConnectionRestored += (s, e) => restoredRaised = true;
+
+            info.Close();
+
+            // A reconnect that committed just before Close() must not report the connection as up again.
+            info.TriggerRestored();
+
+            restoredRaised.Should().BeFalse();
+        }
+
+        [Fact]
+        public void OnConnectionRestored_IsRaised_WhenNotClosed()
+        {
+            var info = CreateWithoutSyncContext();
+            bool restoredRaised = false;
+            info.ConnectionRestored += (s, e) => restoredRaised = true;
+
+            info.TriggerRestored();
+
+            restoredRaised.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Connect_DisposesTheProxy_WhenOpeningFails()
+        {
+            var service = new FakeInfoService();
+            var info = new TestConnectionInfo(infoService: service);
+
+            Action act = () => info.Connect();
+
+            act.Should().Throw<Exception>();
+
+            // The caller never received the proxy, so nobody else can dispose it.
+            service.LastProxy.WasDisposed.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Connect_DiscardsTheStaleProxy_WhenReplacingItFails()
+        {
+            var service = new FakeInfoService { FirstProxyOpens = true };
+            var info = new TestConnectionInfo(infoService: service);
+
+            info.Connect();
+
+            // Closes the channel without clearing it, so the next Connect() takes the replacement path.
+            service.OpenedProxy.Abort();
+
+            Action act = () => info.Connect();
+
+            // Sets up the state under test: disposes the stale proxy, then fails to open its replacement.
+            act.Should().Throw<Exception>();
+
+            // The attempt under test. Both throw, so only the call count tells recovery from tripping
+            // over the disposed proxy: reaching CreateProxy a third time means _proxy was cleared.
+            act.Should().Throw<Exception>();
+            service.CreateProxyCount.Should().Be(3);
+
+            info.Close();
+        }
+
+        private static TestConnectionInfo CreateWithoutSyncContext()
+        {
+            var previous = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            try
+            {
+                return new TestConnectionInfo();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(previous);
+            }
+        }
+
+        private class TestConnectionInfo : ConnectionInfo
+        {
+            public TestConnectionInfo(string server = "localhost", string user = "user", string pass = "pass", string type = "Orion (v3)", FakeInfoService infoService = null)
+                : base(server, user, pass, type, infoService ?? new FakeInfoService())
+            {
+            }
+
+            public void TriggerRestored() => OnConnectionRestored();
+
+            internal new ConnectionInfo Copy()
+            {
+                return new TestConnectionInfo(Server, UserName, Password, ServerType)
+                {
+                    QueryParameters = QueryParameters
+                };
+            }
+        }
+
+        private class FakeInfoService : InfoServiceBase
+        {
+            private readonly string _serviceType;
+
+            public FakeInfoService(string serviceType = "Orion (v3)")
+            {
+                _serviceType = serviceType;
+                _binding = new CustomBinding();
+                _credentials = new FakeServiceCredentials();
+                _endpoint = string.Empty;
+                _endpointConfigName = string.Empty;
+            }
+
+            public override string ServiceType => _serviceType;
+
+            /// <summary>Makes the first proxy openable, so a later Connect() has a live proxy to replace.</summary>
+            public bool FirstProxyOpens { get; set; }
+
+            public UnopenableProxy LastProxy { get; private set; }
+
+            public InfoServiceProxy OpenedProxy { get; private set; }
+
+            public int CreateProxyCount { get; private set; }
+
+            public override InfoServiceProxy CreateProxy(string server)
+            {
+                CreateProxyCount++;
+
+                if (FirstProxyOpens && CreateProxyCount == 1)
+                {
+                    OpenedProxy = new LocalHttpProxy(_credentials);
+                    return OpenedProxy;
+                }
+
+                LastProxy = new UnopenableProxy(_credentials);
+                return LastProxy;
+            }
+        }
+
+        /// <summary>An HTTP channel opens without contacting the server, so nothing has to listen on the port.</summary>
+        private class LocalHttpProxy : InfoServiceProxy
+        {
+            public LocalHttpProxy(ServiceCredentials credentials)
+                : base(new Uri("http://127.0.0.1:1/unused"), CreateBinding(), credentials)
+            {
+            }
+
+            // Disposal probes the dead endpoint; skipping proxy discovery keeps that from taking seconds.
+            private static BasicHttpBinding CreateBinding()
+            {
+                return new BasicHttpBinding
+                {
+                    UseDefaultWebProxy = false,
+                    OpenTimeout = TimeSpan.FromMilliseconds(200),
+                    SendTimeout = TimeSpan.FromMilliseconds(200),
+                    CloseTimeout = TimeSpan.FromMilliseconds(200)
+                };
+            }
+        }
+
+        /// <summary>Its binding carries no transport element, so Open() fails while creating the channel.</summary>
+        private class UnopenableProxy : InfoServiceProxy
+        {
+            public UnopenableProxy(ServiceCredentials credentials)
+                : base(new Uri("http://localhost/unused"), new CustomBinding(), credentials)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+                base.Dispose(disposing);
+            }
+        }
+
+        private class FakeServiceCredentials : ServiceCredentials
+        {
+            public override CredentialType CredentialType => CredentialType.Username;
+
+            public override void ApplyTo(ChannelFactory channelFactory)
+            {
+                // no-op for tests
+            }
+        }
+    }
+}

--- a/Src/Test/SwqlStudio.Tests/ConnectionVisualTests.cs
+++ b/Src/Test/SwqlStudio.Tests/ConnectionVisualTests.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using SolarWinds.InformationService.Contract2;
+using FluentAssertions;
+using SwqlStudio;
+using Xunit;
+
+namespace SwqlStudio.Tests
+{
+    public class ConnectionVisualTests
+    {
+        private static void RunInSta(Action action)
+        {
+            Exception ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception e)
+                {
+                    ex = e;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (ex != null)
+                throw ex;
+        }
+
+        [Fact]
+        public void QueryTab_ShowsDisconnected_OnConnectionClosed()
+        {
+            RunInSta(() =>
+            {
+                var tab = new QueryTab();
+                var connection = new TestConnectionInfoWrapper("localhost", "user", "pass", "Orion (v3)");
+                tab.ConnectionInfo = connection;
+
+                // Simulate auto-disconnect event
+                connection.TriggerClosed();
+                System.Windows.Forms.Application.DoEvents(); // Process queued messages
+
+                tab.CurrentStatus.Should().Be("Disconnected");
+            });
+        }
+
+        [Fact]
+        public void QueryTab_ShowsConnected_OnConnectionRestored()
+        {
+            RunInSta(() =>
+            {
+                var tab = new QueryTab();
+                var connection = new TestConnectionInfoWrapper("localhost", "user", "pass", "Orion (v3)");
+                tab.ConnectionInfo = connection;
+
+                // Simulate disconnect then restore
+                connection.TriggerClosed();
+                System.Windows.Forms.Application.DoEvents(); // Process queued messages
+                connection.SimulatedConnected = true; // a real restore means the channel is back up
+                connection.TriggerRestored();
+                System.Windows.Forms.Application.DoEvents(); // Process queued messages
+
+                tab.CurrentStatus.Should().Be("Connected");
+            });
+        }
+
+        [Fact]
+        public void QueryTab_Resubscribes_WhenConnectionInfoChanges()
+        {
+            RunInSta(() =>
+            {
+                var tab = new QueryTab();
+                var c1 = new TestConnectionInfoWrapper("server1", "user", "pass", "Orion (v3)");
+                var c2 = new TestConnectionInfoWrapper("server2", "user", "pass", "Orion (v3)");
+
+                tab.ConnectionInfo = c1;
+                c1.TriggerClosed();
+                System.Windows.Forms.Application.DoEvents(); // Process queued messages
+                tab.CurrentStatus.Should().Be("Disconnected");
+
+                tab.ConnectionInfo = c2;
+                c2.SimulatedConnected = true; // a real restore means the channel is back up
+                c2.TriggerRestored();
+                System.Windows.Forms.Application.DoEvents(); // Process queued messages
+                tab.CurrentStatus.Should().Be("Connected");
+            });
+        }
+
+        [Fact]
+        public void QueryTab_ShowsDisconnected_WhenConnectionIsNotOpen()
+        {
+            RunInSta(() =>
+            {
+                var tab = new QueryTab();
+                var connection = new TestConnectionInfoWrapper("offline-server", "user", "pass", "Orion (v3)");
+
+                tab.ConnectionInfo = connection;
+
+                tab.CurrentStatus.Should().Be("Disconnected");
+            });
+        }
+
+        [Fact]
+        public void QueryTab_KeepsDisconnected_WhenConnectionIsReassigned()
+        {
+            RunInSta(() =>
+            {
+                var tab = new QueryTab();
+                var connection = new TestConnectionInfoWrapper("offline-server", "user", "pass", "Orion (v3)");
+                tab.ConnectionInfo = connection;
+
+                connection.TriggerClosed();
+                System.Windows.Forms.Application.DoEvents();
+                tab.CurrentStatus.Should().Be("Disconnected");
+
+                // Switching tabs reassigns the same connection; status must not revert to Connected
+                tab.ConnectionInfo = connection;
+
+                tab.CurrentStatus.Should().Be("Disconnected");
+            });
+        }
+
+        [Fact]
+        public void QueryTab_ShowsDisconnected_WhenRestoredHandlerRunsAfterClose()
+        {
+            RunInSta(() =>
+            {
+                var tab = new QueryTab();
+                var connection = new TestConnectionInfoWrapper("server", "user", "pass", "Orion (v3)");
+                connection.SimulatedConnected = true;
+                tab.ConnectionInfo = connection;
+                tab.CurrentStatus.Should().Be("Connected");
+
+                connection.Close();
+                connection.SimulatedConnected = false; // Close() drops the proxy
+
+                // The handler itself is invoked after Close(); the tab must still render the real state.
+                InvokeConnectionRestoredHandler(tab, connection);
+                System.Windows.Forms.Application.DoEvents();
+
+                tab.CurrentStatus.Should().Be("Disconnected");
+            });
+        }
+
+        /// <summary>Calls the handler directly to simulate a stale event delivered after Close().</summary>
+        private static void InvokeConnectionRestoredHandler(QueryTab tab, ConnectionInfo connection)
+        {
+            var handler = typeof(QueryTab).GetMethod(
+                "_connectionInfo_ConnectionRestored",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+            handler.Should().NotBeNull("the test targets the QueryTab connection-restored handler");
+            handler.Invoke(tab, new object[] { connection, EventArgs.Empty });
+        }
+
+        [Fact]
+        public void QueryStatusBar_IdleStateReflectsConnection_RatherThanReadyLiteral()
+        {
+            RunInSta(() =>
+            {
+                var statusBar = new QueryStatusBar();
+                var connection = new TestConnectionInfoWrapper("offline-server", "user", "pass", "Orion (v3)");
+                statusBar.Initialize(connection);
+
+                // What a finished query now shows instead of "Ready"
+                statusBar.ShowConnectionState();
+
+                statusBar.ConnectionStatus.Should().Be("Disconnected");
+            });
+        }
+
+        [Fact]
+        public void QueryTab_IgnoresConnectionEvents_AfterDisposal()
+        {
+            RunInSta(() =>
+            {
+                var connection = new TestConnectionInfoWrapper("server", "user", "pass", "Orion (v3)");
+                var tab = new QueryTab();
+                tab.ConnectionInfo = connection;
+
+                tab.Dispose();
+
+                Action raiseAfterDisposal = () =>
+                {
+                    connection.TriggerClosed();
+                    connection.TriggerRestored();
+                    System.Windows.Forms.Application.DoEvents();
+                };
+
+                raiseAfterDisposal.Should().NotThrow();
+            });
+        }
+
+        [Fact]
+        public void QueryTab_IsNotRetainedByConnection_AfterDisposal()
+        {
+            RunInSta(() =>
+            {
+                var connection = new TestConnectionInfoWrapper("server", "user", "pass", "Orion (v3)");
+
+                WeakReference tabReference = CreateAndDisposeTab(connection);
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+
+                // A still-attached event handler would keep the disposed tab alive.
+                tabReference.IsAlive.Should().BeFalse();
+            });
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static WeakReference CreateAndDisposeTab(ConnectionInfo connection)
+        {
+            var tab = new QueryTab { ConnectionInfo = connection };
+            tab.Dispose();
+            return new WeakReference(tab);
+        }
+
+        private class TestConnectionInfoWrapper : ConnectionInfo
+        {
+            public TestConnectionInfoWrapper(string server, string username, string password, string serverType)
+                : base(server, username, password, serverType, new FakeInfoService())
+            {
+            }
+
+            public void TriggerClosed() => OnConnectionLost();
+            public void TriggerRestored() => OnConnectionRestored();
+
+            /// <summary>Stands in for a live channel, which a fake proxy cannot provide.</summary>
+            public bool SimulatedConnected { get; set; }
+
+            public override bool IsConnected => SimulatedConnected;
+        }
+
+        private class FakeInfoService : InfoServiceBase
+        {
+            private readonly string _serviceType;
+
+            public FakeInfoService(string serviceType = "Orion (v3)")
+            {
+                _serviceType = serviceType;
+                _binding = new CustomBinding();
+                _credentials = new FakeServiceCredentials();
+                _endpoint = string.Empty;
+                _endpointConfigName = string.Empty;
+            }
+
+            public override string ServiceType => _serviceType;
+
+            public override InfoServiceProxy CreateProxy(string server)
+            {
+                return null;
+            }
+        }
+
+        private class FakeServiceCredentials : ServiceCredentials
+        {
+            public override CredentialType CredentialType => CredentialType.Username;
+
+            public override void ApplyTo(ChannelFactory channelFactory)
+            {
+                // no-op
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

SWQL Studio holds a single proxy for the lifetime of a connection and only discovers it has died when a query fails. Meanwhile the status bar keeps reporting `Connected` at startup and `Ready` after every query, regardless of what the connection is actually doing, so a dropped connection looks healthy until the next query throws.

## What this changes

**Keep-alive monitoring and automatic reconnect** (`ConnectionInfo`)

A background monitor polls the channel and, once it drops, retries in the background until it is back. Reconnect is transactional: the replacement proxy and its `InformationServiceConnection` are opened off to the side and committed under `_proxyLock` only when *both* succeed, so a partial failure cannot corrupt live state. A generation counter plus an `_isClosed` flag let an in-flight attempt detect that `Close()` or a competing reconnect won the race while it was opening, in which case it discards its replacement rather than silently reopening a connection the user closed.

`ConnectionsManager` now removes the server from the list on `ConnectionClosing` instead of `ConnectionClosed`, because the latter also fires on transient drops that the monitor is about to recover from.

**Live connection state in the UI** (`QueryStatusBar`, `QueryTab`, `MainForm`)

The status bar renders the real state, and the execute button turns gold while the connection is down and retrying.

The handlers deliberately ignore *which* event arrived and re-read `ConnectionInfo.IsConnected` instead. A restored event can always be delivered after `Close()`, because the connection cannot hold its lock across a WinForms callback without risking deadlock. Deriving the label from live state makes that harmless: a stale restored event renders `Disconnected` once the proxy is gone. `ConnectionClosing` keeps a literal, as a transient progress message is not derivable from `IsConnected`.

`QueryTab` attaches and detaches through one pair of helpers and detaches on disposal, so a long-lived connection no longer retains disposed tabs.

## Notes for reviewers

- `ConnectionInfo.IsConnected` becomes `virtual` purely so tests can stand in for a live channel, which a fake proxy cannot provide. No production behaviour depends on it.
- Both commits build and pass on their own, so the history is bisectable rather than only green at the tip.

## Testing

Added `ConnectionInfoTests` and `ConnectionVisualTests` covering reconnect ownership transfer, disposal of proxies that fail to open, recovery after a failed replacement, suppression of stale restored events, and tab detachment on disposal.

Full suite: **40/40 passing** (built with Visual Studio MSBuild; `dotnet test` cannot build this project's legacy WinForms resources, `MSB3822`/`MSB3823`).

## Demo
<img width="1271" height="924" alt="20260907-SWQLs+" src="https://github.com/user-attachments/assets/354a7f13-e672-4236-bd53-9d23092c9ac4" />
